### PR TITLE
Fix IMAP folder synchronization for deletes and moves

### DIFF
--- a/src/account.vala
+++ b/src/account.vala
@@ -487,6 +487,9 @@ public class Mail.Message : Object {
     public string? conversation_key { get; set; }
     public string? search_blob { get; set; }
     public bool local_only { get; set; }
+    public string? transfer_source_uid { get; set; }
+    public string? transfer_source_folder { get; set; }
+    public bool pending_important_removal { get; set; }
 
     public bool is_placeholder {
         get {

--- a/src/application.vala
+++ b/src/application.vala
@@ -307,6 +307,17 @@ public class Mail.Application : Adw.Application {
             return;
         }
 
+        /* Moves, deletes and flag changes are queued in memory for responsive
+         * UI. Drain them before destroying MailSession and its Camel services. */
+        var mail_windows = new GenericArray<Window> ();
+        foreach (var window in get_windows ()) {
+            var mail = window as Window;
+            if (mail != null)
+                mail_windows.add (mail);
+        }
+        for (uint i = 0; i < mail_windows.length; i++)
+            yield mail_windows[i].prepare_to_close ();
+
         this.shutting_down = true;
         var windows = new GenericArray<Gtk.Window> ();
         foreach (var window in get_windows ())

--- a/src/mail-session.vala
+++ b/src/mail-session.vala
@@ -15,6 +15,7 @@ public class Mail.MailSession : Camel.Session {
     private HashTable<string, MessageContent> body_cache;
     private GenericArray<FlagFlushJob> flag_flush_queue;
     private HashTable<string, FlagFlushJob> flag_flush_latest;
+    private HashTable<string, FlagFlushJob> flag_flush_retries;
     private bool flag_flush_running;
     private GenericArray<TransferFlushJob> transfer_flush_queue;
     private HashTable<string, uint> transfer_pending;
@@ -79,6 +80,7 @@ public class Mail.MailSession : Camel.Session {
         this.body_cache = new HashTable<string, MessageContent> (str_hash, str_equal);
         this.flag_flush_queue = new GenericArray<FlagFlushJob> ();
         this.flag_flush_latest = new HashTable<string, FlagFlushJob> (str_hash, str_equal);
+        this.flag_flush_retries = new HashTable<string, FlagFlushJob> (str_hash, str_equal);
         this.transfer_flush_queue = new GenericArray<TransferFlushJob> ();
         this.transfer_pending = new HashTable<string, uint> (str_hash, str_equal);
         this.folder_watches = new HashTable<string, FolderWatch> (str_hash, str_equal);
@@ -354,6 +356,7 @@ public class Mail.MailSession : Camel.Session {
         public Account account;
         public Folder folder;
         public GenericArray<string> uids;
+        public bool expunge;
     }
 
     private class TransferFlushJob {
@@ -2084,22 +2087,29 @@ public class Mail.MailSession : Camel.Session {
 #else
         GenericArray<string>? transferred = null;
 #endif
+        var copy_completed = false;
         yield enter_camel (true);
         try {
             yield source_folder.transfer_messages_to (uids, dest_folder, true, Priority.DEFAULT, cancellable, out transferred);
+            copy_completed = true;
             /* IMAP servers without UID MOVE implement this as COPY plus a
              * local \Deleted flag. Push and expunge that source-side flag now. */
             yield source_folder.synchronize (true, Priority.DEFAULT, cancellable);
+        } catch (Error e) {
+            if (copy_completed)
+                enqueue_flag_flush (account, from, uids, true);
+            throw e;
         } finally {
             leave_camel (true);
         }
-        var new_uid = uid;
+        string? new_uid = null;
         if (transferred != null && transferred.length > 0 && transferred[0] != null && transferred[0].length > 0)
             new_uid = transferred[0];
-        rekey_body (account, from, uid, destination, new_uid);
+        if (new_uid != null)
+            rekey_body (account, from, uid, destination, new_uid);
         apply_camel_counts (from, source_folder);
         apply_camel_counts (destination, dest_folder);
-        return new_uid;
+        return new_uid ?? "";
     }
 
     public async string copy_message (Account account, Folder from, string uid, Folder destination, Cancellable? cancellable = null) throws Error {
@@ -2118,12 +2128,12 @@ public class Mail.MailSession : Camel.Session {
         } finally {
             leave_camel (true);
         }
-        var new_uid = uid;
+        string? new_uid = null;
         if (transferred != null && transferred.length > 0 && transferred[0] != null && transferred[0].length > 0)
             new_uid = transferred[0];
         apply_camel_counts (from, source_folder);
         apply_camel_counts (destination, dest_folder);
-        return new_uid;
+        return new_uid ?? "";
     }
 
     public void enqueue_move_messages (
@@ -2191,6 +2201,7 @@ public class Mail.MailSession : Camel.Session {
 
     /* Push deferred flag/move/copy jobs (call from sync-interval / manual refresh). */
     public async void flush_pending_local_changes () {
+        stage_flag_flush_retries ();
         if (this.flag_flush_queue.length > 0)
             Utils.sync_log ("flushing deferred flags (%u queue)".printf (this.flag_flush_queue.length));
         if (this.transfer_flush_queue.length > 0)
@@ -2470,17 +2481,43 @@ public class Mail.MailSession : Camel.Session {
         return "%s\n%s".printf (account.source_uid ?? account.uid, folder.full_name);
     }
 
-    private void enqueue_flag_flush (Account account, Folder folder, GenericArray<string> uids) {
+    private void enqueue_flag_flush (
+        Account account,
+        Folder folder,
+        GenericArray<string> uids,
+        bool expunge = false
+    ) {
+        var key = flag_flush_key (account, folder);
+        var previous = this.flag_flush_latest.get (key);
         var job = new FlagFlushJob () {
             account = account,
             folder = folder,
             uids = uids,
+            expunge = expunge || (previous != null && previous.expunge),
         };
-        this.flag_flush_latest.set (flag_flush_key (account, folder), job);
+        this.flag_flush_latest.set (key, job);
+        this.flag_flush_retries.remove (key);
         this.flag_flush_queue.add (job);
         /* Cache-first: local Camel flags are already set. Server push waits for
          * sync-interval / manual refresh (flush_pending_local_changes). */
-        Utils.sync_log ("flag flush deferred “%s” %u messages".printf (folder.name, uids.length));
+        Utils.sync_log ("flag flush deferred “%s” %u messages%s".printf (
+            folder.name,
+            uids.length,
+            job.expunge ? " + expunge" : ""
+        ));
+    }
+
+    /* Failed EXPUNGE jobs stay pending without spinning the current flush.
+     * The next periodic/manual/shutdown flush stages one retry. */
+    private void stage_flag_flush_retries () {
+        var jobs = new GenericArray<FlagFlushJob> ();
+        this.flag_flush_retries.foreach ((key, job) => {
+            if (this.flag_flush_latest.get (key) == job)
+                jobs.add (job);
+        });
+        this.flag_flush_retries.remove_all ();
+        for (uint i = 0; i < jobs.length; i++)
+            this.flag_flush_queue.add (jobs[i]);
     }
 
     private async void pump_flag_flush () {
@@ -2509,7 +2546,9 @@ public class Mail.MailSession : Camel.Session {
             camel_folder = yield open_camel_folder (job.account, job.folder, null);
         } catch (Error e) {
             warning ("Could not push folder flags: %s", e.message);
-            if (this.flag_flush_latest.get (key) == job)
+            if (job.expunge && this.flag_flush_latest.get (key) == job)
+                this.flag_flush_retries.set (key, job);
+            else if (this.flag_flush_latest.get (key) == job)
                 this.flag_flush_latest.remove (key);
             return;
         }
@@ -2517,6 +2556,7 @@ public class Mail.MailSession : Camel.Session {
         var t0 = Utils.sync_tick ();
         var logged_pause = false;
         var done = 0u;
+        var failed = false;
         while (done < job.uids.length) {
             if (this.flag_flush_latest.get (key) != job)
                 return;
@@ -2540,10 +2580,11 @@ public class Mail.MailSession : Camel.Session {
             try {
                 /* synchronize_message only downloads bodies. Flag/follow-up/SEEN
                  * uploads go through folder.synchronize → backend save_flags. */
-                yield camel_folder.synchronize (false, Priority.LOW, null);
+                yield camel_folder.synchronize (job.expunge, Priority.LOW, null);
                 done = job.uids.length;
             } catch (Error e) {
                 warning ("Could not push folder flags for “%s”: %s", job.folder.name, e.message);
+                failed = true;
                 done = job.uids.length;
             } finally {
                 leave_camel (false);
@@ -2563,6 +2604,10 @@ public class Mail.MailSession : Camel.Session {
         if (this.flag_flush_latest.get (key) != job)
             return;
         apply_camel_counts (job.folder, camel_folder);
+        if (failed && job.expunge) {
+            this.flag_flush_retries.set (key, job);
+            return;
+        }
         this.flag_flush_latest.remove (key);
     }
 
@@ -2668,16 +2713,16 @@ public class Mail.MailSession : Camel.Session {
             }
 
             for (uint i = 0; i < batch.length; i++) {
-                var new_uid = batch[i];
+                string? new_uid = null;
                 if (transferred != null && i < transferred.length
                     && transferred[i] != null && transferred[i].length > 0)
                     new_uid = transferred[i];
-                if (job.delete_original)
+                if (job.delete_original && new_uid != null)
                     rekey_body (job.account, job.from, batch[i], job.destination, new_uid);
                 var message_index = done + i;
                 if (job.messages != null && message_index < job.messages.length) {
                     var message = job.messages[message_index];
-                    if (message != null && new_uid != message.uid) {
+                    if (message != null && new_uid != null && new_uid != message.uid) {
                         if (job.delete_original) {
                             rekey_body (
                                 job.account,
@@ -2689,7 +2734,10 @@ public class Mail.MailSession : Camel.Session {
                         }
                         message.uid = new_uid;
                     }
-                    if (message != null)
+                    /* Without COPYUID the destination UID is unknown. Retain
+                     * the unique local placeholder until header reconciliation
+                     * can match the real destination message safely. */
+                    if (message != null && new_uid != null)
                         message.local_only = false;
                 }
             }
@@ -2722,6 +2770,10 @@ public class Mail.MailSession : Camel.Session {
                 }
             } catch (Error e) {
                 warning ("Could not expunge moved messages: %s", e.message);
+                /* The copies already have destination UIDs. Keep the source
+                 * \Deleted flags queued so the next local-change flush retries
+                 * only the delete side instead of copying messages again. */
+                enqueue_flag_flush (job.account, job.from, job.uids, true);
                 transfer_error = transfer_error == null
                     ? e.message
                     : "%s; %s".printf (transfer_error, e.message);

--- a/src/mail-session.vala
+++ b/src/mail-session.vala
@@ -65,6 +65,7 @@ public class Mail.MailSession : Camel.Session {
         Folder destination,
         GenericArray<string> uids,
         GenericArray<Message>? messages,
+        GenericArray<TransferCountChange>? count_changes,
         string error
     );
 
@@ -390,6 +391,7 @@ public class Mail.MailSession : Camel.Session {
         public Folder destination;
         public GenericArray<string> uids;
         public GenericArray<Message>? messages;
+        public GenericArray<TransferCountChange>? count_changes;
         public bool delete_original;
     }
 
@@ -2553,7 +2555,8 @@ public class Mail.MailSession : Camel.Session {
         Folder from,
         Folder destination,
         GenericArray<string> uids,
-        GenericArray<Message>? messages
+        GenericArray<Message>? messages,
+        GenericArray<TransferCountChange>? count_changes = null
     ) {
         if (uids.length == 0)
             return;
@@ -2564,6 +2567,7 @@ public class Mail.MailSession : Camel.Session {
             destination = destination,
             uids = uids,
             messages = messages,
+            count_changes = count_changes,
             delete_original = true,
         };
         bump_transfer_pending (account, from, 1);
@@ -2586,7 +2590,8 @@ public class Mail.MailSession : Camel.Session {
         Folder from,
         Folder destination,
         GenericArray<string> uids,
-        GenericArray<Message>? messages
+        GenericArray<Message>? messages,
+        GenericArray<TransferCountChange>? count_changes = null
     ) {
         if (uids.length == 0)
             return;
@@ -2597,6 +2602,7 @@ public class Mail.MailSession : Camel.Session {
             destination = destination,
             uids = uids,
             messages = messages,
+            count_changes = count_changes,
             delete_original = false,
         };
         bump_transfer_pending (account, from, 1);
@@ -3306,6 +3312,11 @@ public class Mail.MailSession : Camel.Session {
             this.transfer_pending.set (key, n);
     }
 
+    private uint transfer_pending_count (Account account, Folder folder) {
+        var key = flag_flush_key (account, folder);
+        return this.transfer_pending.contains (key) ? this.transfer_pending.get (key) : 0;
+    }
+
     private async void pump_transfer_flush () {
         if (this.transfer_flush_running)
             return;
@@ -3483,8 +3494,13 @@ public class Mail.MailSession : Camel.Session {
             return;
         }
 
-        apply_camel_counts (job.from, source_folder);
-        apply_camel_counts (job.destination, dest_folder);
+        /* A later queued transfer may already be represented optimistically in
+         * Folder counts but not in Camel yet. Preserve those deltas until the
+         * last job touching each folder has finished. */
+        if (transfer_pending_count (job.account, job.from) <= 1)
+            apply_camel_counts (job.from, source_folder);
+        if (transfer_pending_count (job.account, job.destination) <= 1)
+            apply_camel_counts (job.destination, dest_folder);
         bump_transfer_pending (job.account, job.from, -1);
         if (job.from.full_name != job.destination.full_name)
             bump_transfer_pending (job.account, job.destination, -1);
@@ -3505,12 +3521,19 @@ public class Mail.MailSession : Camel.Session {
             for (uint i = done; i < job.messages.length; i++)
                 remaining_messages.add (job.messages[i]);
         }
+        GenericArray<TransferCountChange>? remaining_count_changes = null;
+        if (job.count_changes != null) {
+            remaining_count_changes = new GenericArray<TransferCountChange> ();
+            for (uint i = done; i < job.count_changes.length; i++)
+                remaining_count_changes.add (job.count_changes[i]);
+        }
         this.transfer_failed (
             job.account,
             job.from,
             job.destination,
             remaining,
             remaining_messages,
+            remaining_count_changes,
             error
         );
     }
@@ -4654,6 +4677,13 @@ public class Mail.Recipient : Object {
             return display;
         }
     }
+}
+
+public class Mail.TransferCountChange : Object {
+    public bool source_total_decremented;
+    public bool source_unread_decremented;
+    public bool destination_total_incremented;
+    public bool destination_unread_incremented;
 }
 
 public class Mail.MessageContent : Object {

--- a/src/mail-session.vala
+++ b/src/mail-session.vala
@@ -1372,7 +1372,8 @@ public class Mail.MailSession : Camel.Session {
             var replacement = matching_live_transfer (live, pending.candidate, claimed);
             if (replacement == null)
                 continue;
-            if (pending.candidate.uid.has_prefix ("local-copy-")) {
+            var copy = pending.candidate.uid.has_prefix ("local-copy-");
+            if (copy) {
                 /* Copies retain their source body. Only promote a body that
                  * was opened under the destination placeholder. */
                 rekey_body (
@@ -1392,7 +1393,10 @@ public class Mail.MailSession : Camel.Session {
                     live.remove_index (j);
             }
             pending.resolved_uid = replacement.uid;
-            if (pending.body_path == null)
+            /* A copy has no recovery snapshot because its source remains in
+             * place. Keep that source→destination mapping until Camel has
+             * durably cached the destination body. */
+            if (pending.body_path == null && !copy)
                 this.pending_body_rekeys.remove_index (i);
             changed = true;
         }

--- a/src/mail-session.vala
+++ b/src/mail-session.vala
@@ -6,6 +6,14 @@ private class Mail.FolderWatch : Object {
     public uint idle;
 }
 
+private class Mail.PendingBodyRekey : Object {
+    public string account_key;
+    public Folder from;
+    public string uid;
+    public Folder destination;
+    public Message candidate;
+}
+
 public class Mail.MailSession : Camel.Session {
     public E.SourceRegistry registry { get; construct; }
 
@@ -20,6 +28,7 @@ public class Mail.MailSession : Camel.Session {
     private GenericArray<TransferFlushJob> transfer_flush_queue;
     private HashTable<string, uint> transfer_pending;
     private bool transfer_flush_running;
+    private GenericArray<PendingBodyRekey> pending_body_rekeys;
     private HashTable<string, FolderWatch> folder_watches;
     private HashTable<string, int> prefetch_cursor;
     private bool camel_busy;
@@ -84,6 +93,7 @@ public class Mail.MailSession : Camel.Session {
         this.flag_flush_retries = new HashTable<string, FlagFlushJob> (str_hash, str_equal);
         this.transfer_flush_queue = new GenericArray<TransferFlushJob> ();
         this.transfer_pending = new HashTable<string, uint> (str_hash, str_equal);
+        this.pending_body_rekeys = new GenericArray<PendingBodyRekey> ();
         this.folder_watches = new HashTable<string, FolderWatch> (str_hash, str_equal);
         this.prefetch_cursor = new HashTable<string, int> (str_hash, str_equal);
     }
@@ -630,6 +640,7 @@ public class Mail.MailSession : Camel.Session {
 
         apply_counts_from_messages (folder, messages);
         messages = retain_local_only (account, folder, messages, previous);
+        resolve_pending_body_rekeys (account, folder, messages);
         Conversation.prune_duplicate_sends (messages);
         apply_counts_from_messages (folder, messages);
         return messages;
@@ -652,6 +663,7 @@ public class Mail.MailSession : Camel.Session {
             );
         }
         var messages = yield collect_messages (account, camel_folder, folder, null);
+        resolve_pending_body_rekeys (account, folder, messages);
         apply_counts_from_messages (folder, messages);
         return messages;
     }
@@ -708,6 +720,7 @@ public class Mail.MailSession : Camel.Session {
                 return -1;
             return 0;
         });
+        resolve_pending_body_rekeys (account, folder, messages);
         return messages;
     }
 
@@ -1274,6 +1287,58 @@ public class Mail.MailSession : Camel.Session {
         return null;
     }
 
+    private void resolve_pending_body_rekeys (
+        Account account,
+        Folder folder,
+        GenericArray<Message> live
+    ) {
+        var account_key = account.source_uid ?? account.uid;
+        var claimed = new HashTable<string, uint8> (str_hash, str_equal);
+        for (int i = (int) this.pending_body_rekeys.length - 1; i >= 0; i--) {
+            var pending = this.pending_body_rekeys[i];
+            if (pending.account_key != account_key
+                || pending.destination.full_name != folder.full_name)
+                continue;
+
+            var replacement = matching_live_transfer (live, pending.candidate, claimed);
+            if (replacement == null)
+                continue;
+            rekey_body (account, pending.from, pending.uid, folder, replacement.uid);
+            claimed.set (replacement.uid, 1);
+            this.pending_body_rekeys.remove_index (i);
+        }
+    }
+
+    private static Message? matching_live_transfer (
+        GenericArray<Message> live,
+        Message candidate,
+        HashTable<string, uint8> claimed
+    ) {
+        Message? match = null;
+        for (uint i = 0; i < live.length; i++) {
+            var message = live[i];
+            if (message.is_placeholder || claimed.contains (message.uid))
+                continue;
+
+            var same = candidate.msgid_hash != 0
+                ? message.msgid_hash == candidate.msgid_hash
+                : Conversation.same_outgoing_send (message, candidate)
+                    || (message.subject == candidate.subject
+                        && message.from == candidate.from
+                        && message.to == candidate.to
+                        && message.date == candidate.date);
+            if (!same)
+                continue;
+            /* Without COPYUID there is no safe way to choose between duplicate
+             * destination messages. Keep the source-keyed body until a later
+             * refresh provides an unambiguous match. */
+            if (match != null)
+                return null;
+            match = message;
+        }
+        return match;
+    }
+
     private static bool uses_outlook_flag_semantics (Account account) {
         return account.kind == AccountKind.MICROSOFT || account.kind == AccountKind.EXCHANGE;
     }
@@ -1747,6 +1812,7 @@ public class Mail.MailSession : Camel.Session {
 
         var before_prune = messages.length;
         Conversation.prune_duplicate_sends (messages);
+        resolve_pending_body_rekeys (account, folder, messages);
         if (added == 0 && messages.length == before_prune)
             return 0;
         if (added == 0)
@@ -1793,6 +1859,20 @@ public class Mail.MailSession : Camel.Session {
             return cached;
 
         var camel_folder = yield open_camel_folder (account, folder, null);
+        if (this.pending_body_rekeys.length > 0) {
+            var info = camel_folder.get_message_info (uid);
+            if (info != null && !message_info_is_deleted (info)) {
+                var outgoing = folder.kind == FolderKind.SENT
+                    || folder.kind == FolderKind.DRAFTS
+                    || folder.kind == FolderKind.OUTBOX;
+                var live = new GenericArray<Message> ();
+                live.add (message_from_info (account, uid, info, folder, outgoing, camel_folder));
+                resolve_pending_body_rekeys (account, folder, live);
+                cached = this.body_cache.get (key);
+                if (cached != null)
+                    return cached;
+            }
+        }
         var mime = message_from_local_cache (camel_folder, uid);
         if (mime != null)
             Utils.sync_log ("open body “%s” uid=%s from disk".printf (folder.name, uid));
@@ -2088,6 +2168,19 @@ public class Mail.MailSession : Camel.Session {
         var source_folder = yield open_camel_folder (account, from, cancellable);
         var dest_folder = yield open_camel_folder (account, destination, cancellable);
         yield capture_local_body (account, from, uid, source_folder);
+        Message? body_candidate = null;
+        var info = source_folder.get_message_info (uid);
+        if (info != null) {
+            var outgoing = from.kind == FolderKind.SENT
+                || from.kind == FolderKind.DRAFTS
+                || from.kind == FolderKind.OUTBOX;
+            body_candidate = message_from_info (account, uid, info, from, outgoing, source_folder);
+            body_candidate.local_only = true;
+            var cached = peek_body (account, from, uid);
+            if (body_candidate.msgid_hash == 0 && cached != null
+                && cached.message_id != null && cached.message_id.length > 0)
+                body_candidate.msgid_hash = hash_message_id (cached.message_id, true);
+        }
         var uids = new GenericArray<string> ();
         uids.add (uid);
 #if HAVE_CAMEL_3_58
@@ -2104,17 +2197,33 @@ public class Mail.MailSession : Camel.Session {
              * local \Deleted flag. Push and expunge that source-side flag now. */
             yield source_folder.synchronize (true, Priority.DEFAULT, cancellable);
         } catch (Error e) {
-            if (copy_completed)
-                enqueue_flag_flush (account, from, uids, true);
-            throw e;
+            if (!copy_completed)
+                throw e;
+            /* The destination copy already exists and the source is locally
+             * marked \Deleted. Treat the move as pending so callers cannot
+             * repeat the copy while a later flush retries only EXPUNGE. */
+            warning ("Could not expunge moved message: %s", e.message);
+            enqueue_flag_flush (account, from, uids, true);
         } finally {
             leave_camel (true);
         }
         string? new_uid = null;
         if (transferred != null && transferred.length > 0 && transferred[0] != null && transferred[0].length > 0)
             new_uid = transferred[0];
-        if (new_uid != null)
+        if (new_uid != null) {
             rekey_body (account, from, uid, destination, new_uid);
+        } else if (body_candidate != null && peek_body (account, from, uid) != null) {
+            /* Servers without COPYUID cannot identify the destination body key
+             * yet. Reconcile it once that folder exposes one unique matching
+             * header, retaining the source-keyed body in the meantime. */
+            this.pending_body_rekeys.add (new PendingBodyRekey () {
+                account_key = account.source_uid ?? account.uid,
+                from = from,
+                uid = uid,
+                destination = destination,
+                candidate = body_candidate,
+            });
+        }
         apply_camel_counts (from, source_folder);
         apply_camel_counts (destination, dest_folder);
         return new_uid ?? "";
@@ -2784,9 +2893,8 @@ public class Mail.MailSession : Camel.Session {
                  * \Deleted flags queued so the next local-change flush retries
                  * only the delete side instead of copying messages again. */
                 enqueue_flag_flush (job.account, job.from, job.uids, true);
-                transfer_error = transfer_error == null
-                    ? e.message
-                    : "%s; %s".printf (transfer_error, e.message);
+                if (transfer_error != null)
+                    transfer_error = "%s; %s".printf (transfer_error, e.message);
             }
         }
 
@@ -3059,6 +3167,11 @@ public class Mail.MailSession : Camel.Session {
         });
         for (uint i = 0; i < keys.length; i++)
             this.body_cache.remove (keys[i]);
+        var account_key = account.source_uid ?? account.uid;
+        for (int i = (int) this.pending_body_rekeys.length - 1; i >= 0; i--) {
+            if (this.pending_body_rekeys[i].account_key == account_key)
+                this.pending_body_rekeys.remove_index (i);
+        }
     }
 
     private static uint64 directory_size (string path) {

--- a/src/mail-session.vala
+++ b/src/mail-session.vala
@@ -12,6 +12,16 @@ private class Mail.PendingBodyRekey : Object {
     public string uid;
     public Folder destination;
     public Message candidate;
+    public string? resolved_uid;
+    public string? body_path;
+}
+
+private class Mail.PendingExpunge : Object {
+    public string account_key;
+    public string folder_full_name;
+    public string folder_name;
+    public uint folder_flags;
+    public string uid;
 }
 
 public class Mail.MailSession : Camel.Session {
@@ -29,6 +39,7 @@ public class Mail.MailSession : Camel.Session {
     private HashTable<string, uint> transfer_pending;
     private bool transfer_flush_running;
     private GenericArray<PendingBodyRekey> pending_body_rekeys;
+    private HashTable<string, PendingExpunge> persisted_expunges;
     private HashTable<string, FolderWatch> folder_watches;
     private HashTable<string, int> prefetch_cursor;
     private bool camel_busy;
@@ -94,8 +105,10 @@ public class Mail.MailSession : Camel.Session {
         this.transfer_flush_queue = new GenericArray<TransferFlushJob> ();
         this.transfer_pending = new HashTable<string, uint> (str_hash, str_equal);
         this.pending_body_rekeys = new GenericArray<PendingBodyRekey> ();
+        this.persisted_expunges = new HashTable<string, PendingExpunge> (str_hash, str_equal);
         this.folder_watches = new HashTable<string, FolderWatch> (str_hash, str_equal);
         this.prefetch_cursor = new HashTable<string, int> (str_hash, str_equal);
+        load_pending_sync_state ();
     }
 
     public override void dispose () {
@@ -348,6 +361,7 @@ public class Mail.MailSession : Camel.Session {
         reshape_gmail_tree (roots);
         sort_folder_nodes (roots);
         flatten_folder_nodes (roots, 0, folders, false, false);
+        resume_persisted_expunges (account, folders);
         Utils.sync_log ("Camel get_folder_info refresh=%s %s → %u folders".printf (
             refresh.to_string (),
             Utils.sync_ms (t0),
@@ -1276,10 +1290,19 @@ public class Mail.MailSession : Camel.Session {
     ) {
         var account_key = account.source_uid ?? account.uid;
         var claimed = new HashTable<string, uint8> (str_hash, str_equal);
+        for (uint i = 0; i < this.pending_body_rekeys.length; i++) {
+            var pending = this.pending_body_rekeys[i];
+            if (pending.account_key == account_key
+                && pending.destination.full_name == folder.full_name
+                && pending.resolved_uid != null)
+                claimed.set (pending.resolved_uid, 1);
+        }
+        var changed = false;
         for (int i = (int) this.pending_body_rekeys.length - 1; i >= 0; i--) {
             var pending = this.pending_body_rekeys[i];
             if (pending.account_key != account_key
-                || pending.destination.full_name != folder.full_name)
+                || pending.destination.full_name != folder.full_name
+                || pending.resolved_uid != null)
                 continue;
 
             var replacement = matching_live_transfer (live, pending.candidate, claimed);
@@ -1287,8 +1310,11 @@ public class Mail.MailSession : Camel.Session {
                 continue;
             rekey_body (account, pending.from, pending.uid, folder, replacement.uid);
             claimed.set (replacement.uid, 1);
-            this.pending_body_rekeys.remove_index (i);
+            pending.resolved_uid = replacement.uid;
+            changed = true;
         }
+        if (changed)
+            save_pending_sync_state ();
     }
 
     private bool folder_has_pending_body_rekeys (Account account, Folder folder) {
@@ -1296,10 +1322,114 @@ public class Mail.MailSession : Camel.Session {
         for (uint i = 0; i < this.pending_body_rekeys.length; i++) {
             var pending = this.pending_body_rekeys[i];
             if (pending.account_key == account_key
-                && pending.destination.full_name == folder.full_name)
+                && pending.destination.full_name == folder.full_name
+                && pending.resolved_uid == null)
                 return true;
         }
         return false;
+    }
+
+    private PendingBodyRekey? resolved_body_rekey (
+        Account account,
+        Folder folder,
+        string uid
+    ) {
+        var account_key = account.source_uid ?? account.uid;
+        for (uint i = 0; i < this.pending_body_rekeys.length; i++) {
+            var pending = this.pending_body_rekeys[i];
+            if (pending.account_key == account_key
+                && pending.destination.full_name == folder.full_name
+                && pending.resolved_uid == uid)
+                return pending;
+        }
+        return null;
+    }
+
+    private void finish_body_rekey (PendingBodyRekey pending) {
+        for (int i = (int) this.pending_body_rekeys.length - 1; i >= 0; i--) {
+            if (this.pending_body_rekeys[i] != pending)
+                continue;
+            this.pending_body_rekeys.remove_index (i);
+            discard_pending_body (pending);
+            save_pending_sync_state ();
+            return;
+        }
+    }
+
+    private static string pending_body_cache_dir () {
+        return Path.build_filename (
+            Environment.get_user_data_dir (),
+            "letter",
+            "pending-bodies"
+        );
+    }
+
+    private static string pending_body_cache_file (PendingBodyRekey pending) {
+        var identity = "%s\n%s\n%s\n%s".printf (
+            pending.account_key,
+            pending.from.full_name,
+            pending.uid,
+            pending.destination.full_name
+        );
+        return Path.build_filename (
+            pending_body_cache_dir (),
+            Checksum.compute_for_string (ChecksumType.SHA256, identity) + ".eml"
+        );
+    }
+
+    private void persist_pending_body (
+        PendingBodyRekey pending,
+        Camel.MimeMessage mime
+    ) {
+        var path = pending_body_cache_file (pending);
+        try {
+            File.new_for_path (pending_body_cache_dir ()).make_directory_with_parents ();
+        } catch (Error e) {
+            if (!(e is IOError.EXISTS)) {
+                warning ("Could not create pending body cache: %s", e.message);
+                return;
+            }
+        }
+        try {
+            var output = File.new_for_path (path).replace (
+                null,
+                false,
+                FileCreateFlags.REPLACE_DESTINATION,
+                null
+            );
+            mime.write_to_output_stream_sync (output, null);
+            output.close (null);
+            pending.body_path = path;
+        } catch (Error e) {
+            warning ("Could not preserve moved message body: %s", e.message);
+        }
+    }
+
+    private static Camel.MimeMessage? load_pending_body (PendingBodyRekey pending) {
+        if (pending.body_path == null || !FileUtils.test (pending.body_path, FileTest.IS_REGULAR))
+            return null;
+        try {
+            var input = File.new_for_path (pending.body_path).read (null);
+            var mime = new Camel.MimeMessage ();
+            mime.construct_from_input_stream_sync (input, null);
+            input.close (null);
+            return mime;
+        } catch (Error e) {
+            warning ("Could not restore moved message body: %s", e.message);
+            return null;
+        }
+    }
+
+    private static void discard_pending_body (PendingBodyRekey pending) {
+        if (pending.body_path == null)
+            return;
+        try {
+            File.new_for_path (pending.body_path).delete ();
+        } catch (Error e) {
+            if (!(e is IOError.NOT_FOUND))
+                debug ("Could not remove completed moved body: %s", e.message);
+        }
+        pending.body_path = null;
     }
 
     private static Message? matching_live_transfer (
@@ -1851,8 +1981,20 @@ public class Mail.MailSession : Camel.Session {
         if (cached != null)
             return cached;
 
-        var camel_folder = yield open_camel_folder (account, folder, null);
-        if (folder_has_pending_body_rekeys (account, folder)) {
+        var pending = resolved_body_rekey (account, folder, uid);
+        if (pending != null) {
+            var durable = load_pending_body (pending);
+            if (durable != null) {
+                var restored = MessageContent.from_mime (uid, durable);
+                this.body_cache.set (key, restored);
+                return restored;
+            }
+        }
+
+        var has_unresolved_rekey = folder_has_pending_body_rekeys (account, folder);
+        var defer_online = pending != null || has_unresolved_rekey;
+        var camel_folder = yield open_camel_folder (account, folder, null, !defer_online);
+        if (has_unresolved_rekey) {
             /* A singleton candidate cannot establish uniqueness: the folder
              * may already contain another message with the same Message-ID or
              * fallback fingerprint. Resolve only against the complete summary. */
@@ -1861,16 +2003,47 @@ public class Mail.MailSession : Camel.Session {
             cached = this.body_cache.get (key);
             if (cached != null)
                 return cached;
+            pending = resolved_body_rekey (account, folder, uid);
+            if (pending != null) {
+                defer_online = true;
+                var durable = load_pending_body (pending);
+                if (durable != null) {
+                    var restored = MessageContent.from_mime (uid, durable);
+                    this.body_cache.set (key, restored);
+                    return restored;
+                }
+            }
         }
         var mime = message_from_local_cache (camel_folder, uid);
-        if (mime != null)
+        var destination_cached = mime != null;
+        if (mime != null) {
             Utils.sync_log ("open body “%s” uid=%s from disk".printf (folder.name, uid));
+        } else if (pending != null) {
+            /* A no-COPYUID move can leave the only offline copy outside the
+             * destination cache. Keep the durable MIME snapshot and mapping
+             * until Camel also has the body under the destination UID. */
+            mime = load_pending_body (pending);
+            if (mime == null) {
+                try {
+                    var source = yield open_camel_folder (account, pending.from, cancellable, false);
+                    mime = message_from_local_cache (source, pending.uid);
+                } catch (Error e) {
+                    debug ("Could not open moved body cache for %s: %s", uid, e.message);
+                }
+            }
+            if (mime != null)
+                Utils.sync_log ("open body “%s” uid=%s from moved disk cache".printf (folder.name, uid));
+        }
         if (mime == null) {
+            if (defer_online)
+                camel_folder = yield open_camel_folder (account, folder, cancellable, true);
             Utils.sync_log ("open body “%s” uid=%s from server".printf (folder.name, uid));
             try {
                 mime = yield fetch_camel_message (camel_folder, uid, Priority.DEFAULT);
+                destination_cached = message_from_local_cache (camel_folder, uid) != null;
             } catch (Error e) {
                 mime = message_from_local_cache (camel_folder, uid);
+                destination_cached = mime != null;
                 if (mime == null) {
                     if (is_missing_on_server (e)) {
                         throw new IOError.NOT_FOUND (
@@ -1889,6 +2062,8 @@ public class Mail.MailSession : Camel.Session {
 
         var fetched = MessageContent.from_mime (uid, mime);
         this.body_cache.set (key, fetched);
+        if (pending != null && destination_cached)
+            finish_body_rekey (pending);
         return fetched;
     }
 
@@ -2156,7 +2331,7 @@ public class Mail.MailSession : Camel.Session {
     public async string move_message (Account account, Folder from, string uid, Folder destination, Cancellable? cancellable = null) throws Error {
         var source_folder = yield open_camel_folder (account, from, cancellable);
         var dest_folder = yield open_camel_folder (account, destination, cancellable);
-        yield capture_local_body (account, from, uid, source_folder);
+        var local_mime = yield capture_local_body (account, from, uid, source_folder);
         Message? body_candidate = null;
         var info = source_folder.get_message_info (uid);
         if (info != null) {
@@ -2169,6 +2344,18 @@ public class Mail.MailSession : Camel.Session {
             if (body_candidate.msgid_hash == 0 && cached != null
                 && cached.message_id != null && cached.message_id.length > 0)
                 body_candidate.msgid_hash = hash_message_id (cached.message_id, true);
+        }
+        PendingBodyRekey? pending_rekey = null;
+        if (body_candidate != null && peek_body (account, from, uid) != null) {
+            pending_rekey = new PendingBodyRekey () {
+                account_key = account.source_uid ?? account.uid,
+                from = from,
+                uid = uid,
+                destination = destination,
+                candidate = body_candidate,
+            };
+            if (local_mime != null)
+                persist_pending_body (pending_rekey, local_mime);
         }
         var uids = new GenericArray<string> ();
         uids.add (uid);
@@ -2186,8 +2373,11 @@ public class Mail.MailSession : Camel.Session {
              * local \Deleted flag. Push and expunge that source-side flag now. */
             yield source_folder.synchronize (true, Priority.DEFAULT, cancellable);
         } catch (Error e) {
-            if (!copy_completed)
+            if (!copy_completed) {
+                if (pending_rekey != null)
+                    discard_pending_body (pending_rekey);
                 throw e;
+            }
             /* The destination copy already exists and the source is locally
              * marked \Deleted. Treat the move as pending so callers cannot
              * repeat the copy while a later flush retries only EXPUNGE. */
@@ -2200,18 +2390,15 @@ public class Mail.MailSession : Camel.Session {
         if (transferred != null && transferred.length > 0 && transferred[0] != null && transferred[0].length > 0)
             new_uid = transferred[0];
         if (new_uid != null) {
+            if (pending_rekey != null)
+                discard_pending_body (pending_rekey);
             rekey_body (account, from, uid, destination, new_uid);
-        } else if (body_candidate != null && peek_body (account, from, uid) != null) {
+        } else if (pending_rekey != null) {
             /* Servers without COPYUID cannot identify the destination body key
              * yet. Reconcile it once that folder exposes one unique matching
              * header, retaining the source-keyed body in the meantime. */
-            this.pending_body_rekeys.add (new PendingBodyRekey () {
-                account_key = account.source_uid ?? account.uid,
-                from = from,
-                uid = uid,
-                destination = destination,
-                candidate = body_candidate,
-            });
+            this.pending_body_rekeys.add (pending_rekey);
+            save_pending_sync_state ();
         }
         apply_camel_counts (from, source_folder);
         apply_camel_counts (destination, dest_folder);
@@ -2316,7 +2503,9 @@ public class Mail.MailSession : Camel.Session {
         pump_transfer_flush.begin ();
 
         /* begin() is used during normal operation, but shutdown must be able
-         * to wait until both in-memory queues have actually drained. */
+         * to wait until both in-memory queues have actually drained. A failed
+         * EXPUNGE may return to the retry table; those jobs are journaled when
+         * queued and restored on the next account-folder load. */
         while (this.flag_flush_running || this.transfer_flush_running
             || this.flag_flush_queue.length > 0 || this.transfer_flush_queue.length > 0) {
             Timeout.add (50, flush_pending_local_changes.callback);
@@ -2594,6 +2783,222 @@ public class Mail.MailSession : Camel.Session {
         return "%s\n%s".printf (account.source_uid ?? account.uid, folder.full_name);
     }
 
+    private static string pending_sync_state_file () {
+        return Path.build_filename (
+            Environment.get_user_data_dir (),
+            "letter",
+            "pending-sync-state"
+        );
+    }
+
+    private static string pending_sync_group (string kind, string identity) {
+        return "%s-%s".printf (
+            kind,
+            Checksum.compute_for_string (ChecksumType.SHA256, identity)
+        );
+    }
+
+    private void load_pending_sync_state () {
+        var path = pending_sync_state_file ();
+        if (!FileUtils.test (path, FileTest.IS_REGULAR))
+            return;
+
+        var state = new KeyFile ();
+        try {
+            state.load_from_file (path, KeyFileFlags.NONE);
+        } catch (Error e) {
+            warning ("Could not read pending mail synchronization state: %s", e.message);
+            return;
+        }
+
+        foreach (var group in state.get_groups ()) {
+            try {
+                if (group.has_prefix ("expunge-")) {
+                    var pending = new PendingExpunge () {
+                        account_key = state.get_string (group, "account"),
+                        folder_full_name = state.get_string (group, "folder"),
+                        folder_name = state.get_string (group, "folder-name"),
+                        folder_flags = (uint) state.get_uint64 (group, "folder-flags"),
+                        uid = state.get_string (group, "uid"),
+                    };
+                    this.persisted_expunges.set (
+                        "%s\n%s".printf (pending.account_key, pending.folder_full_name),
+                        pending
+                    );
+                    continue;
+                }
+                if (!group.has_prefix ("body-"))
+                    continue;
+
+                var from_name = state.get_string (group, "from-name");
+                var from_full_name = state.get_string (group, "from-folder");
+                var destination_name = state.get_string (group, "destination-name");
+                var destination_full_name = state.get_string (group, "destination-folder");
+                var outgoing = state.get_boolean (group, "outgoing");
+                string? resolved_uid = null;
+                if (state.has_key (group, "resolved-uid")) {
+                    var stored = state.get_string (group, "resolved-uid");
+                    if (stored.length > 0)
+                        resolved_uid = stored;
+                }
+                var candidate = new Message () {
+                    uid = state.get_string (group, "uid"),
+                    subject = state.get_string (group, "subject"),
+                    from = state.get_string (group, "from"),
+                    to = state.get_string (group, "to"),
+                    date = state.get_int64 (group, "date"),
+                    outgoing = outgoing,
+                    local_only = true,
+                    msgid_hash = state.get_uint64 (group, "message-id-hash"),
+                    folder_name = from_name,
+                    folder_full_name = from_full_name,
+                    list_address = "",
+                };
+                var pending = new PendingBodyRekey () {
+                    account_key = state.get_string (group, "account"),
+                    from = new Folder () {
+                        name = from_name,
+                        full_name = from_full_name,
+                        flags = (uint) state.get_uint64 (group, "from-flags"),
+                    },
+                    uid = candidate.uid,
+                    destination = new Folder () {
+                        name = destination_name,
+                        full_name = destination_full_name,
+                        flags = (uint) state.get_uint64 (group, "destination-flags"),
+                    },
+                    candidate = candidate,
+                    resolved_uid = resolved_uid,
+                };
+                var body_path = pending_body_cache_file (pending);
+                if (FileUtils.test (body_path, FileTest.IS_REGULAR))
+                    pending.body_path = body_path;
+                this.pending_body_rekeys.add (pending);
+            } catch (Error e) {
+                warning ("Could not restore pending mail synchronization item: %s", e.message);
+            }
+        }
+    }
+
+    private void save_pending_sync_state () {
+        var state = new KeyFile ();
+        this.persisted_expunges.foreach ((identity, pending) => {
+            var group = pending_sync_group ("expunge", identity);
+            state.set_string (group, "account", pending.account_key);
+            state.set_string (group, "folder", pending.folder_full_name);
+            state.set_string (group, "folder-name", pending.folder_name);
+            state.set_uint64 (group, "folder-flags", pending.folder_flags);
+            state.set_string (group, "uid", pending.uid);
+        });
+        for (uint i = 0; i < this.pending_body_rekeys.length; i++) {
+            var pending = this.pending_body_rekeys[i];
+            var identity = "%s\n%s\n%s\n%s".printf (
+                pending.account_key,
+                pending.from.full_name,
+                pending.uid,
+                pending.destination.full_name
+            );
+            var group = pending_sync_group ("body", identity);
+            state.set_string (group, "account", pending.account_key);
+            state.set_string (group, "from-folder", pending.from.full_name);
+            state.set_string (group, "from-name", pending.from.name);
+            state.set_uint64 (group, "from-flags", pending.from.flags);
+            state.set_string (group, "uid", pending.uid);
+            state.set_string (group, "destination-folder", pending.destination.full_name);
+            state.set_string (group, "destination-name", pending.destination.name);
+            state.set_uint64 (group, "destination-flags", pending.destination.flags);
+            state.set_string (group, "subject", pending.candidate.subject ?? "");
+            state.set_string (group, "from", pending.candidate.from ?? "");
+            state.set_string (group, "to", pending.candidate.to ?? "");
+            state.set_int64 (group, "date", pending.candidate.date);
+            state.set_boolean (group, "outgoing", pending.candidate.outgoing);
+            state.set_uint64 (group, "message-id-hash", pending.candidate.msgid_hash);
+            if (pending.resolved_uid != null)
+                state.set_string (group, "resolved-uid", pending.resolved_uid);
+        }
+
+        var path = pending_sync_state_file ();
+        if (this.persisted_expunges.size () == 0 && this.pending_body_rekeys.length == 0) {
+            try {
+                File.new_for_path (path).delete ();
+            } catch (Error e) {
+                if (!(e is IOError.NOT_FOUND))
+                    debug ("Could not remove completed synchronization state: %s", e.message);
+            }
+            return;
+        }
+
+        try {
+            File.new_for_path (Path.get_dirname (path)).make_directory_with_parents ();
+        } catch (Error e) {
+            if (!(e is IOError.EXISTS)) {
+                warning ("Could not create pending synchronization directory: %s", e.message);
+                return;
+            }
+        }
+        try {
+            state.save_to_file (path);
+        } catch (Error e) {
+            warning ("Could not save pending mail synchronization state: %s", e.message);
+        }
+    }
+
+    private void remember_persisted_expunge (FlagFlushJob job) {
+        if (!job.expunge || job.uids.length == 0)
+            return;
+        var key = flag_flush_key (job.account, job.folder);
+        this.persisted_expunges.set (key, new PendingExpunge () {
+            account_key = job.account.source_uid ?? job.account.uid,
+            folder_full_name = job.folder.full_name,
+            folder_name = job.folder.name,
+            folder_flags = job.folder.flags,
+            uid = job.uids[0],
+        });
+        save_pending_sync_state ();
+    }
+
+    private void resume_persisted_expunges (
+        Account account,
+        GenericArray<Folder> folders
+    ) {
+        var account_key = account.source_uid ?? account.uid;
+        uint resumed = 0;
+        this.persisted_expunges.foreach ((key, pending) => {
+            if (pending.account_key != account_key || this.flag_flush_latest.contains (key))
+                return;
+
+            Folder? folder = null;
+            for (uint i = 0; i < folders.length; i++) {
+                if (folders[i].full_name == pending.folder_full_name) {
+                    folder = folders[i];
+                    break;
+                }
+            }
+            if (folder == null) {
+                folder = new Folder () {
+                    name = pending.folder_name,
+                    full_name = pending.folder_full_name,
+                    flags = pending.folder_flags,
+                };
+            }
+            var uids = new GenericArray<string> ();
+            uids.add (pending.uid);
+            var job = new FlagFlushJob () {
+                account = account,
+                folder = folder,
+                uids = uids,
+                expunge = true,
+            };
+            this.flag_flush_latest.set (key, job);
+            this.flag_flush_queue.add (job);
+            resumed++;
+        });
+        if (resumed == 0)
+            return;
+        Utils.sync_log ("restored %u pending expunge jobs".printf (resumed));
+        pump_flag_flush.begin ();
+    }
+
     private void enqueue_flag_flush (
         Account account,
         Folder folder,
@@ -2611,6 +3016,7 @@ public class Mail.MailSession : Camel.Session {
         this.flag_flush_latest.set (key, job);
         this.flag_flush_retries.remove (key);
         this.flag_flush_queue.add (job);
+        remember_persisted_expunge (job);
         /* Cache-first: local Camel flags are already set. Server push waits for
          * sync-interval / manual refresh (flush_pending_local_changes). */
         Utils.sync_log ("flag flush deferred “%s” %u messages%s".printf (
@@ -2722,6 +3128,8 @@ public class Mail.MailSession : Camel.Session {
             return;
         }
         this.flag_flush_latest.remove (key);
+        if (job.expunge && this.persisted_expunges.remove (key))
+            save_pending_sync_state ();
         if (!failed)
             this.folder_flags_flushed (job.account, job.folder);
     }
@@ -3002,13 +3410,16 @@ public class Mail.MailSession : Camel.Session {
         return camel_folder.get_message_cached (uid, null);
     }
 
-    private async void capture_local_body (Account account, Folder folder, string uid, Camel.Folder camel_folder) {
-        if (this.body_cache.contains (body_key (account, folder, uid)))
-            return;
-
+    private async Camel.MimeMessage? capture_local_body (
+        Account account,
+        Folder folder,
+        string uid,
+        Camel.Folder camel_folder
+    ) {
         var mime = message_from_local_cache (camel_folder, uid);
-        if (mime != null)
+        if (mime != null && !this.body_cache.contains (body_key (account, folder, uid)))
             this.body_cache.set (body_key (account, folder, uid), MessageContent.from_mime (uid, mime));
+        return mime;
     }
 
     private static bool is_missing_on_server (Error error) {
@@ -3018,14 +3429,19 @@ public class Mail.MailSession : Camel.Session {
             || text.contains ("not found in the store");
     }
 
-    private async Camel.Folder open_camel_folder (Account account, Folder folder, Cancellable? cancellable) throws Error {
+    private async Camel.Folder open_camel_folder (
+        Account account,
+        Folder folder,
+        Cancellable? cancellable,
+        bool online = true
+    ) throws Error {
         if (folder.is_virtual_view) {
             throw new IOError.NOT_SUPPORTED (
                 _("“%s” is a local view, not a mail folder.").printf (folder.name)
             );
         }
 
-        var store = yield open_store (account, cancellable);
+        var store = yield open_store (account, cancellable, online);
         var camel_folder = yield store.get_folder (
             folder.full_name,
             Camel.StoreGetFolderFlags.NONE,
@@ -3047,6 +3463,20 @@ public class Mail.MailSession : Camel.Session {
 
     private void drop_body (Account account, Folder folder, string uid) {
         this.body_cache.remove (body_key (account, folder, uid));
+        var account_key = account.source_uid ?? account.uid;
+        var changed = false;
+        for (int i = (int) this.pending_body_rekeys.length - 1; i >= 0; i--) {
+            var pending = this.pending_body_rekeys[i];
+            if (pending.account_key != account_key
+                || pending.destination.full_name != folder.full_name
+                || pending.resolved_uid != uid)
+                continue;
+            discard_pending_body (pending);
+            this.pending_body_rekeys.remove_index (i);
+            changed = true;
+        }
+        if (changed)
+            save_pending_sync_state ();
     }
 
     public static string mail_data_root () {
@@ -3165,9 +3595,19 @@ public class Mail.MailSession : Camel.Session {
             this.body_cache.remove (keys[i]);
         var account_key = account.source_uid ?? account.uid;
         for (int i = (int) this.pending_body_rekeys.length - 1; i >= 0; i--) {
-            if (this.pending_body_rekeys[i].account_key == account_key)
+            if (this.pending_body_rekeys[i].account_key == account_key) {
+                discard_pending_body (this.pending_body_rekeys[i]);
                 this.pending_body_rekeys.remove_index (i);
+            }
         }
+        var expunge_keys = new GenericArray<string> ();
+        this.persisted_expunges.foreach ((key, pending) => {
+            if (pending.account_key == account_key)
+                expunge_keys.add (key);
+        });
+        for (uint i = 0; i < expunge_keys.length; i++)
+            this.persisted_expunges.remove (expunge_keys[i]);
+        save_pending_sync_state ();
     }
 
     private static uint64 directory_size (string path) {

--- a/src/mail-session.vala
+++ b/src/mail-session.vala
@@ -1372,7 +1372,19 @@ public class Mail.MailSession : Camel.Session {
             var replacement = matching_live_transfer (live, pending.candidate, claimed);
             if (replacement == null)
                 continue;
-            rekey_body (account, pending.from, pending.uid, folder, replacement.uid);
+            if (pending.candidate.uid.has_prefix ("local-copy-")) {
+                /* Copies retain their source body. Only promote a body that
+                 * was opened under the destination placeholder. */
+                rekey_body (
+                    account,
+                    folder,
+                    pending.candidate.uid,
+                    folder,
+                    replacement.uid
+                );
+            } else {
+                rekey_body (account, pending.from, pending.uid, folder, replacement.uid);
+            }
             claimed.set (replacement.uid, 1);
             for (int j = (int) live.length - 1; j >= 0; j--) {
                 if (live[j].is_placeholder
@@ -2935,12 +2947,15 @@ public class Mail.MailSession : Camel.Session {
                 var destination_full_name = state.get_string (group, "destination-folder");
                 var outgoing = state.get_boolean (group, "outgoing");
                 var stored_uid = state.get_string (group, "uid");
-                var candidate_uid = stored_uid;
-                if (stored_uid.has_prefix ("local-move-")) {
+                var stored_candidate_uid = state.has_key (group, "candidate-uid")
+                    ? state.get_string (group, "candidate-uid")
+                    : stored_uid;
+                var candidate_uid = stored_candidate_uid;
+                if (stored_candidate_uid.has_prefix ("local-move-")) {
                     candidate_uid = "local-move-pending-%s".printf (
                         group.substring ("body-".length)
                     );
-                } else if (stored_uid.has_prefix ("local-copy-")) {
+                } else if (stored_candidate_uid.has_prefix ("local-copy-")) {
                     candidate_uid = "local-copy-pending-%s".printf (
                         group.substring ("body-".length)
                     );
@@ -3026,6 +3041,7 @@ public class Mail.MailSession : Camel.Session {
             state.set_string (group, "from-name", pending.from.name);
             state.set_uint64 (group, "from-flags", pending.from.flags);
             state.set_string (group, "uid", pending.uid);
+            state.set_string (group, "candidate-uid", pending.candidate.uid);
             state.set_string (group, "destination-folder", pending.destination.full_name);
             state.set_string (group, "destination-name", pending.destination.name);
             state.set_uint64 (group, "destination-flags", pending.destination.flags);
@@ -3402,8 +3418,8 @@ public class Mail.MailSession : Camel.Session {
                          * can persist caches that intentionally omit placeholders. */
                         var pending = new PendingBodyRekey () {
                             account_key = job.account.source_uid ?? job.account.uid,
-                            from = job.destination,
-                            uid = message.uid,
+                            from = job.delete_original ? job.destination : job.from,
+                            uid = job.delete_original ? message.uid : batch[i],
                             destination = job.destination,
                             candidate = message,
                         };

--- a/src/mail-session.vala
+++ b/src/mail-session.vala
@@ -2386,7 +2386,6 @@ public class Mail.MailSession : Camel.Session {
                     Camel.MessageFlags.DELETED,
                     Camel.MessageFlags.DELETED
                 );
-                drop_body (account, folder, uids[i]);
             }
         } finally {
             camel_folder.thaw ();
@@ -2409,6 +2408,8 @@ public class Mail.MailSession : Camel.Session {
             apply_camel_counts (folder, camel_folder);
             throw e;
         }
+        for (uint i = 0; i < uids.length; i++)
+            drop_body (account, folder, uids[i]);
         apply_camel_counts (folder, camel_folder);
     }
 
@@ -2433,7 +2434,6 @@ public class Mail.MailSession : Camel.Session {
                     Camel.MessageFlags.DELETED,
                     Camel.MessageFlags.DELETED
                 );
-                drop_body (account, folder, raw[i]);
                 uids.add (raw[i]);
             }
         } finally {
@@ -2457,6 +2457,8 @@ public class Mail.MailSession : Camel.Session {
             apply_camel_counts (folder, camel_folder);
             throw e;
         }
+        for (uint i = 0; i < uids.length; i++)
+            drop_body (account, folder, uids[i]);
         folder.unread = 0;
         folder.total = 0;
     }

--- a/src/mail-session.vala
+++ b/src/mail-session.vala
@@ -1434,6 +1434,24 @@ public class Mail.MailSession : Camel.Session {
         return null;
     }
 
+    public bool has_pending_transfer (
+        Account account,
+        Folder folder,
+        string candidate_uid
+    ) {
+        return pending_body_rekey (account, folder, candidate_uid) != null;
+    }
+
+    public void discard_pending_transfer (
+        Account account,
+        Folder folder,
+        string candidate_uid
+    ) {
+        var pending = pending_body_rekey (account, folder, candidate_uid);
+        if (pending != null)
+            finish_body_rekey (pending);
+    }
+
     private void finish_body_rekey (PendingBodyRekey pending) {
         for (int i = (int) this.pending_body_rekeys.length - 1; i >= 0; i--) {
             if (this.pending_body_rekeys[i] != pending)
@@ -3004,6 +3022,12 @@ public class Mail.MailSession : Camel.Session {
                     folder_name = from_name,
                     folder_full_name = from_full_name,
                     list_address = "",
+                    transfer_source_uid = stored_candidate_uid.has_prefix ("local-copy-")
+                        ? stored_uid
+                        : null,
+                    transfer_source_folder = stored_candidate_uid.has_prefix ("local-copy-")
+                        ? from_full_name
+                        : null,
                 };
                 var pending = new PendingBodyRekey () {
                     account_key = state.get_string (group, "account"),

--- a/src/mail-session.vala
+++ b/src/mail-session.vala
@@ -1978,18 +1978,9 @@ public class Mail.MailSession : Camel.Session {
     public async MessageContent load_message (Account account, Folder folder, string uid, Cancellable? cancellable = null) throws Error {
         var key = body_key (account, folder, uid);
         var cached = this.body_cache.get (key);
-        if (cached != null)
-            return cached;
-
         var pending = resolved_body_rekey (account, folder, uid);
-        if (pending != null) {
-            var durable = load_pending_body (pending);
-            if (durable != null) {
-                var restored = MessageContent.from_mime (uid, durable);
-                this.body_cache.set (key, restored);
-                return restored;
-            }
-        }
+        if (cached != null && pending == null)
+            return cached;
 
         var has_unresolved_rekey = folder_has_pending_body_rekeys (account, folder);
         var defer_online = pending != null || has_unresolved_rekey;
@@ -2001,21 +1992,18 @@ public class Mail.MailSession : Camel.Session {
             var live = yield collect_messages (account, camel_folder, folder, cancellable);
             resolve_pending_body_rekeys (account, folder, live);
             cached = this.body_cache.get (key);
-            if (cached != null)
-                return cached;
             pending = resolved_body_rekey (account, folder, uid);
-            if (pending != null) {
+            if (pending != null)
                 defer_online = true;
-                var durable = load_pending_body (pending);
-                if (durable != null) {
-                    var restored = MessageContent.from_mime (uid, durable);
-                    this.body_cache.set (key, restored);
-                    return restored;
-                }
-            }
         }
         var mime = message_from_local_cache (camel_folder, uid);
         var destination_cached = mime != null;
+        if (destination_cached && pending != null) {
+            finish_body_rekey (pending);
+            pending = null;
+        }
+        if (cached != null)
+            return cached;
         if (mime != null) {
             Utils.sync_log ("open body “%s” uid=%s from disk".printf (folder.name, uid));
         } else if (pending != null) {
@@ -2091,8 +2079,16 @@ public class Mail.MailSession : Camel.Session {
          * local tags are already set/cleared (pending bookmark write). */
         if (uses_outlook_flag_semantics (account)) {
             var info = camel_folder.get_message_info (uid);
-            if (info != null && !info_has_active_followup (info) && !info.get_folder_flagged ())
-                yield refresh_folder_info (camel_folder, true);
+            if (info != null && !info_has_active_followup (info) && !info.get_folder_flagged ()) {
+                try {
+                    yield refresh_folder_info (camel_folder, true);
+                } catch (Error e) {
+                    /* Scheduled auto-marking already updated the UI. Preserve
+                     * the prior best-effort behavior and queue the local SEEN
+                     * flag instead of leaving client/server state split. */
+                    debug ("Could not refresh Microsoft flags before marking read: %s", e.message);
+                }
+            }
         }
 
         var flags = camel_folder.get_message_flags (uid);

--- a/src/mail-session.vala
+++ b/src/mail-session.vala
@@ -738,6 +738,19 @@ public class Mail.MailSession : Camel.Session {
         return messages;
     }
 
+    public async string? find_matching_uid (
+        Account account,
+        Folder folder,
+        Message candidate,
+        Cancellable? cancellable = null
+    ) throws Error {
+        var camel_folder = yield open_camel_folder (account, folder, cancellable);
+        if (!folder_has_pending_flags (account, folder))
+            yield refresh_folder_info (camel_folder, true);
+        var messages = yield collect_messages (account, camel_folder, folder, cancellable);
+        return matching_message_uid (messages, candidate);
+    }
+
     public static string header_search_expression (SearchQuery query, bool include_body = false) {
         if (query.is_empty)
             return "(match-all false)";
@@ -1299,7 +1312,8 @@ public class Mail.MailSession : Camel.Session {
             if (pending.account_key != account_key
                 || pending.destination.full_name != folder.full_name
                 || pending.resolved_uid != null
-                || !pending.candidate.uid.has_prefix ("local-move-")
+                || !(pending.candidate.uid.has_prefix ("local-move-")
+                    || pending.candidate.uid.has_prefix ("local-copy-"))
                 || have_uid.contains (pending.candidate.uid))
                 continue;
 
@@ -1509,6 +1523,15 @@ public class Mail.MailSession : Camel.Session {
             match = message;
         }
         return match;
+    }
+
+    public static string? matching_message_uid (
+        GenericArray<Message> messages,
+        Message candidate
+    ) {
+        var claimed = new HashTable<string, uint8> (str_hash, str_equal);
+        var match = matching_live_transfer (messages, candidate, claimed);
+        return match != null ? match.uid : null;
     }
 
     private static bool uses_outlook_flag_semantics (Account account) {
@@ -2881,9 +2904,16 @@ public class Mail.MailSession : Camel.Session {
                 var destination_full_name = state.get_string (group, "destination-folder");
                 var outgoing = state.get_boolean (group, "outgoing");
                 var stored_uid = state.get_string (group, "uid");
-                var candidate_uid = stored_uid.has_prefix ("local-move-")
-                    ? "local-move-pending-%s".printf (group.substring ("body-".length))
-                    : stored_uid;
+                var candidate_uid = stored_uid;
+                if (stored_uid.has_prefix ("local-move-")) {
+                    candidate_uid = "local-move-pending-%s".printf (
+                        group.substring ("body-".length)
+                    );
+                } else if (stored_uid.has_prefix ("local-copy-")) {
+                    candidate_uid = "local-copy-pending-%s".printf (
+                        group.substring ("body-".length)
+                    );
+                }
                 string? resolved_uid = null;
                 if (state.has_key (group, "resolved-uid")) {
                     var stored = state.get_string (group, "resolved-uid");
@@ -3334,11 +3364,11 @@ public class Mail.MailSession : Camel.Session {
                      * can match the real destination message safely. */
                     if (message != null && new_uid != null)
                         message.local_only = false;
-                    if (message != null && job.delete_original && new_uid == null) {
-                        /* The server completed the move but supplied no
-                         * destination UID. Journal both the optimistic header
-                         * and any offline body before completion signals can
-                         * persist caches that intentionally omit placeholders. */
+                    if (message != null && new_uid == null) {
+                        /* The server completed the move or copy but supplied
+                         * no destination UID. Journal the optimistic header
+                         * and any offline move body before completion signals
+                         * can persist caches that intentionally omit placeholders. */
                         var pending = new PendingBodyRekey () {
                             account_key = job.account.source_uid ?? job.account.uid,
                             from = job.destination,

--- a/src/mail-session.vala
+++ b/src/mail-session.vala
@@ -2454,6 +2454,10 @@ public class Mail.MailSession : Camel.Session {
                 || from.kind == FolderKind.DRAFTS
                 || from.kind == FolderKind.OUTBOX;
             body_candidate = message_from_info (account, uid, info, from, outgoing, source_folder);
+            /* The source UID cannot identify a row in the destination after a
+             * no-COPYUID move. Give recovery a distinct destination identity
+             * while retaining the real source UID in PendingBodyRekey. */
+            body_candidate.uid = "local-move-%s".printf (Uuid.string_random ());
             body_candidate.local_only = true;
             var cached = peek_body (account, from, uid);
             if (body_candidate.msgid_hash == 0 && cached != null

--- a/src/mail-session.vala
+++ b/src/mail-session.vala
@@ -1351,6 +1351,11 @@ public class Mail.MailSession : Camel.Session {
                 continue;
             rekey_body (account, pending.from, pending.uid, folder, replacement.uid);
             claimed.set (replacement.uid, 1);
+            for (int j = (int) live.length - 1; j >= 0; j--) {
+                if (live[j].is_placeholder
+                    && live[j].uid == pending.candidate.uid)
+                    live.remove_index (j);
+            }
             if (pending.body_path == null)
                 this.pending_body_rekeys.remove_index (i);
             else

--- a/src/mail-session.vala
+++ b/src/mail-session.vala
@@ -652,9 +652,9 @@ public class Mail.MailSession : Camel.Session {
             ));
         }
 
-        apply_counts_from_messages (folder, messages);
-        messages = retain_local_only (account, folder, messages, previous);
         resolve_pending_body_rekeys (account, folder, messages);
+        messages = retain_local_only (account, folder, messages, previous);
+        retain_pending_transfer_placeholders (account, folder, messages);
         Conversation.prune_duplicate_sends (messages);
         apply_counts_from_messages (folder, messages);
         return messages;
@@ -678,6 +678,7 @@ public class Mail.MailSession : Camel.Session {
         }
         var messages = yield collect_messages (account, camel_folder, folder, null);
         resolve_pending_body_rekeys (account, folder, messages);
+        retain_pending_transfer_placeholders (account, folder, messages);
         apply_counts_from_messages (folder, messages);
         return messages;
     }
@@ -734,7 +735,6 @@ public class Mail.MailSession : Camel.Session {
                 return -1;
             return 0;
         });
-        resolve_pending_body_rekeys (account, folder, messages);
         return messages;
     }
 
@@ -1283,6 +1283,47 @@ public class Mail.MailSession : Camel.Session {
         return live;
     }
 
+    private void retain_pending_transfer_placeholders (
+        Account account,
+        Folder folder,
+        GenericArray<Message> live
+    ) {
+        var account_key = account.source_uid ?? account.uid;
+        var have_uid = new HashTable<string, uint8> (str_hash, str_equal);
+        for (uint i = 0; i < live.length; i++)
+            have_uid.set (live[i].uid, 1);
+
+        var added = false;
+        for (uint i = 0; i < this.pending_body_rekeys.length; i++) {
+            var pending = this.pending_body_rekeys[i];
+            if (pending.account_key != account_key
+                || pending.destination.full_name != folder.full_name
+                || pending.resolved_uid != null
+                || !pending.candidate.uid.has_prefix ("local-move-")
+                || have_uid.contains (pending.candidate.uid))
+                continue;
+
+            /* A completed bulk move without COPYUID can outlive the window
+             * that created its optimistic destination row. Restore the row
+             * from the durable rekey journal until a full folder summary can
+             * identify the real destination UID. */
+            Conversation.apply_folder (pending.candidate, folder, pending.candidate.uid);
+            pending.candidate.local_only = true;
+            live.add (pending.candidate);
+            have_uid.set (pending.candidate.uid, 1);
+            added = true;
+        }
+        if (added) {
+            live.sort ((a, b) => {
+                if (a.date < b.date)
+                    return 1;
+                if (a.date > b.date)
+                    return -1;
+                return 0;
+            });
+        }
+    }
+
     private void resolve_pending_body_rekeys (
         Account account,
         Folder folder,
@@ -1310,7 +1351,10 @@ public class Mail.MailSession : Camel.Session {
                 continue;
             rekey_body (account, pending.from, pending.uid, folder, replacement.uid);
             claimed.set (replacement.uid, 1);
-            pending.resolved_uid = replacement.uid;
+            if (pending.body_path == null)
+                this.pending_body_rekeys.remove_index (i);
+            else
+                pending.resolved_uid = replacement.uid;
             changed = true;
         }
         if (changed)
@@ -2831,6 +2875,10 @@ public class Mail.MailSession : Camel.Session {
                 var destination_name = state.get_string (group, "destination-name");
                 var destination_full_name = state.get_string (group, "destination-folder");
                 var outgoing = state.get_boolean (group, "outgoing");
+                var stored_uid = state.get_string (group, "uid");
+                var candidate_uid = stored_uid.has_prefix ("local-move-")
+                    ? "local-move-pending-%s".printf (group.substring ("body-".length))
+                    : stored_uid;
                 string? resolved_uid = null;
                 if (state.has_key (group, "resolved-uid")) {
                     var stored = state.get_string (group, "resolved-uid");
@@ -2838,12 +2886,24 @@ public class Mail.MailSession : Camel.Session {
                         resolved_uid = stored;
                 }
                 var candidate = new Message () {
-                    uid = state.get_string (group, "uid"),
+                    uid = candidate_uid,
                     subject = state.get_string (group, "subject"),
                     from = state.get_string (group, "from"),
                     to = state.get_string (group, "to"),
+                    cc = state.has_key (group, "cc") ? state.get_string (group, "cc") : "",
                     date = state.get_int64 (group, "date"),
                     outgoing = outgoing,
+                    seen = state.has_key (group, "seen") && state.get_boolean (group, "seen"),
+                    flagged = state.has_key (group, "flagged") && state.get_boolean (group, "flagged"),
+                    important = state.has_key (group, "important") && state.get_boolean (group, "important"),
+                    has_attachment = state.has_key (group, "has-attachment")
+                        && state.get_boolean (group, "has-attachment"),
+                    preview = state.has_key (group, "preview")
+                        ? state.get_string (group, "preview")
+                        : null,
+                    conversation_key = state.has_key (group, "conversation-key")
+                        ? state.get_string (group, "conversation-key")
+                        : null,
                     local_only = true,
                     msgid_hash = state.get_uint64 (group, "message-id-hash"),
                     folder_name = from_name,
@@ -2857,7 +2917,7 @@ public class Mail.MailSession : Camel.Session {
                         full_name = from_full_name,
                         flags = (uint) state.get_uint64 (group, "from-flags"),
                     },
-                    uid = candidate.uid,
+                    uid = stored_uid,
                     destination = new Folder () {
                         name = destination_name,
                         full_name = destination_full_name,
@@ -2906,8 +2966,19 @@ public class Mail.MailSession : Camel.Session {
             state.set_string (group, "subject", pending.candidate.subject ?? "");
             state.set_string (group, "from", pending.candidate.from ?? "");
             state.set_string (group, "to", pending.candidate.to ?? "");
+            state.set_string (group, "cc", pending.candidate.cc ?? "");
             state.set_int64 (group, "date", pending.candidate.date);
             state.set_boolean (group, "outgoing", pending.candidate.outgoing);
+            state.set_boolean (group, "seen", pending.candidate.seen);
+            state.set_boolean (group, "flagged", pending.candidate.flagged);
+            state.set_boolean (group, "important", pending.candidate.important);
+            state.set_boolean (group, "has-attachment", pending.candidate.has_attachment);
+            state.set_string (group, "preview", pending.candidate.preview ?? "");
+            state.set_string (
+                group,
+                "conversation-key",
+                pending.candidate.conversation_key ?? ""
+            );
             state.set_uint64 (group, "message-id-hash", pending.candidate.msgid_hash);
             if (pending.resolved_uid != null)
                 state.set_string (group, "resolved-uid", pending.resolved_uid);
@@ -3201,10 +3272,9 @@ public class Mail.MailSession : Camel.Session {
             for (uint i = done; i < end; i++)
                 batch.add (job.uids[i]);
 
-            if (job.delete_original) {
-                for (uint i = 0; i < batch.length; i++)
-                    yield capture_local_body (job.account, job.from, batch[i], source_folder);
-            }
+            Camel.MimeMessage? captured_body = null;
+            if (job.delete_original)
+                captured_body = yield capture_local_body (job.account, job.from, batch[0], source_folder);
 
 #if HAVE_CAMEL_3_58
             GenericArray<weak string>? transferred = null;
@@ -3231,6 +3301,7 @@ public class Mail.MailSession : Camel.Session {
                 break;
             }
 
+            var pending_changed = false;
             for (uint i = 0; i < batch.length; i++) {
                 string? new_uid = null;
                 if (transferred != null && i < transferred.length
@@ -3258,8 +3329,27 @@ public class Mail.MailSession : Camel.Session {
                      * can match the real destination message safely. */
                     if (message != null && new_uid != null)
                         message.local_only = false;
+                    if (message != null && job.delete_original && new_uid == null) {
+                        /* The server completed the move but supplied no
+                         * destination UID. Journal both the optimistic header
+                         * and any offline body before completion signals can
+                         * persist caches that intentionally omit placeholders. */
+                        var pending = new PendingBodyRekey () {
+                            account_key = job.account.source_uid ?? job.account.uid,
+                            from = job.destination,
+                            uid = message.uid,
+                            destination = job.destination,
+                            candidate = message,
+                        };
+                        if (captured_body != null)
+                            persist_pending_body (pending, captured_body);
+                        this.pending_body_rekeys.add (pending);
+                        pending_changed = true;
+                    }
                 }
             }
+            if (pending_changed)
+                save_pending_sync_state ();
 
             done = end;
             if (done == job.uids.length || done % 30 == 0) {

--- a/src/mail-session.vala
+++ b/src/mail-session.vala
@@ -1309,6 +1309,17 @@ public class Mail.MailSession : Camel.Session {
         }
     }
 
+    private bool folder_has_pending_body_rekeys (Account account, Folder folder) {
+        var account_key = account.source_uid ?? account.uid;
+        for (uint i = 0; i < this.pending_body_rekeys.length; i++) {
+            var pending = this.pending_body_rekeys[i];
+            if (pending.account_key == account_key
+                && pending.destination.full_name == folder.full_name)
+                return true;
+        }
+        return false;
+    }
+
     private static Message? matching_live_transfer (
         GenericArray<Message> live,
         Message candidate,
@@ -1859,19 +1870,15 @@ public class Mail.MailSession : Camel.Session {
             return cached;
 
         var camel_folder = yield open_camel_folder (account, folder, null);
-        if (this.pending_body_rekeys.length > 0) {
-            var info = camel_folder.get_message_info (uid);
-            if (info != null && !message_info_is_deleted (info)) {
-                var outgoing = folder.kind == FolderKind.SENT
-                    || folder.kind == FolderKind.DRAFTS
-                    || folder.kind == FolderKind.OUTBOX;
-                var live = new GenericArray<Message> ();
-                live.add (message_from_info (account, uid, info, folder, outgoing, camel_folder));
-                resolve_pending_body_rekeys (account, folder, live);
-                cached = this.body_cache.get (key);
-                if (cached != null)
-                    return cached;
-            }
+        if (folder_has_pending_body_rekeys (account, folder)) {
+            /* A singleton candidate cannot establish uniqueness: the folder
+             * may already contain another message with the same Message-ID or
+             * fallback fingerprint. Resolve only against the complete summary. */
+            var live = yield collect_messages (account, camel_folder, folder, cancellable);
+            resolve_pending_body_rekeys (account, folder, live);
+            cached = this.body_cache.get (key);
+            if (cached != null)
+                return cached;
         }
         var mime = message_from_local_cache (camel_folder, uid);
         if (mime != null)

--- a/src/mail-session.vala
+++ b/src/mail-session.vala
@@ -37,6 +37,7 @@ public class Mail.MailSession : Camel.Session {
     public signal void message_sent (Account account, Message? sent);
     public signal void draft_saved (Account account, Message? draft);
     public signal void draft_removed (Account account, Folder folder, string uid);
+    public signal void folder_flags_flushed (Account account, Folder folder);
     public signal void transfer_completed (Account account, Folder from, Folder destination);
     public signal void transfer_failed (
         Account account,
@@ -628,7 +629,7 @@ public class Mail.MailSession : Camel.Session {
         }
 
         apply_counts_from_messages (folder, messages);
-        messages = retain_local_only (messages, previous);
+        messages = retain_local_only (account, folder, messages, previous);
         Conversation.prune_duplicate_sends (messages);
         apply_counts_from_messages (folder, messages);
         return messages;
@@ -1210,7 +1211,9 @@ public class Mail.MailSession : Camel.Session {
         return result;
     }
 
-    private static GenericArray<Message> retain_local_only (
+    private GenericArray<Message> retain_local_only (
+        Account account,
+        Folder folder,
         GenericArray<Message> live,
         GenericArray<Message>? previous
     ) {
@@ -1230,10 +1233,15 @@ public class Mail.MailSession : Camel.Session {
                 continue;
             if (have_uid.contains (message.uid))
                 continue;
-            if (message.msgid_hash != 0 && live_has_msgid (live, message.msgid_hash))
+            Message? replacement = null;
+            if (message.msgid_hash != 0)
+                replacement = live_with_msgid (live, message.msgid_hash);
+            if (replacement == null)
+                replacement = matching_live_outgoing_send (live, message);
+            if (replacement != null) {
+                rekey_body (account, folder, message.uid, folder, replacement.uid);
                 continue;
-            if (live_has_outgoing_send (live, message))
-                continue;
+            }
             live.add (message);
             added = true;
         }
@@ -1250,20 +1258,20 @@ public class Mail.MailSession : Camel.Session {
         return live;
     }
 
-    private static bool live_has_outgoing_send (GenericArray<Message> live, Message candidate) {
+    private static Message? matching_live_outgoing_send (GenericArray<Message> live, Message candidate) {
         for (uint i = 0; i < live.length; i++) {
             if (Conversation.same_outgoing_send (live[i], candidate))
-                return true;
+                return live[i];
         }
-        return false;
+        return null;
     }
 
-    private static bool live_has_msgid (GenericArray<Message> live, uint64 hash) {
+    private static Message? live_with_msgid (GenericArray<Message> live, uint64 hash) {
         for (uint i = 0; i < live.length; i++) {
             if (live[i].msgid_hash == hash)
-                return true;
+                return live[i];
         }
-        return false;
+        return null;
     }
 
     private static bool uses_outlook_flag_semantics (Account account) {
@@ -2609,6 +2617,8 @@ public class Mail.MailSession : Camel.Session {
             return;
         }
         this.flag_flush_latest.remove (key);
+        if (!failed)
+            this.folder_flags_flushed (job.account, job.folder);
     }
 
     private void bump_transfer_pending (Account account, Folder folder, int delta) {

--- a/src/mail-session.vala
+++ b/src/mail-session.vala
@@ -1239,6 +1239,7 @@ public class Mail.MailSession : Camel.Session {
             live[i].local_only = false;
         }
 
+        var claimed = new HashTable<string, uint8> (str_hash, str_equal);
         var added = false;
         for (uint i = 0; i < previous.length; i++) {
             var message = previous[i];
@@ -1246,13 +1247,10 @@ public class Mail.MailSession : Camel.Session {
                 continue;
             if (have_uid.contains (message.uid))
                 continue;
-            Message? replacement = null;
-            if (message.msgid_hash != 0)
-                replacement = live_with_msgid (live, message.msgid_hash);
-            if (replacement == null)
-                replacement = matching_live_outgoing_send (live, message);
+            var replacement = matching_live_transfer (live, message, claimed);
             if (replacement != null) {
                 rekey_body (account, folder, message.uid, folder, replacement.uid);
+                claimed.set (replacement.uid, 1);
                 continue;
             }
             live.add (message);
@@ -1269,22 +1267,6 @@ public class Mail.MailSession : Camel.Session {
             return 0;
         });
         return live;
-    }
-
-    private static Message? matching_live_outgoing_send (GenericArray<Message> live, Message candidate) {
-        for (uint i = 0; i < live.length; i++) {
-            if (Conversation.same_outgoing_send (live[i], candidate))
-                return live[i];
-        }
-        return null;
-    }
-
-    private static Message? live_with_msgid (GenericArray<Message> live, uint64 hash) {
-        for (uint i = 0; i < live.length; i++) {
-            if (live[i].msgid_hash == hash)
-                return live[i];
-        }
-        return null;
     }
 
     private void resolve_pending_body_rekeys (
@@ -1341,8 +1323,8 @@ public class Mail.MailSession : Camel.Session {
             if (!same)
                 continue;
             /* Without COPYUID there is no safe way to choose between duplicate
-             * destination messages. Keep the source-keyed body until a later
-             * refresh provides an unambiguous match. */
+             * destination messages. Keep the body under its local/source key
+             * until a later refresh provides an unambiguous match. */
             if (match != null)
                 return null;
             match = message;
@@ -2433,14 +2415,19 @@ public class Mail.MailSession : Camel.Session {
         }
 
         var uids = new GenericArray<string> ();
+        var newly_deleted = new GenericArray<string> ();
         camel_folder.freeze ();
         try {
             for (uint i = 0; i < raw.length; i++) {
-                camel_folder.set_message_flags (
-                    raw[i],
-                    Camel.MessageFlags.DELETED,
-                    Camel.MessageFlags.DELETED
-                );
+                var flags = camel_folder.get_message_flags (raw[i]);
+                if ((flags & Camel.MessageFlags.DELETED) == 0) {
+                    camel_folder.set_message_flags (
+                        raw[i],
+                        Camel.MessageFlags.DELETED,
+                        Camel.MessageFlags.DELETED
+                    );
+                    newly_deleted.add (raw[i]);
+                }
                 uids.add (raw[i]);
             }
         } finally {
@@ -2456,8 +2443,8 @@ public class Mail.MailSession : Camel.Session {
         } catch (Error e) {
             camel_folder.freeze ();
             try {
-                for (uint i = 0; i < uids.length; i++)
-                    camel_folder.set_message_flags (uids[i], Camel.MessageFlags.DELETED, 0);
+                for (uint i = 0; i < newly_deleted.length; i++)
+                    camel_folder.set_message_flags (newly_deleted[i], Camel.MessageFlags.DELETED, 0);
             } finally {
                 camel_folder.thaw ();
             }

--- a/src/mail-session.vala
+++ b/src/mail-session.vala
@@ -2613,6 +2613,7 @@ public class Mail.MailSession : Camel.Session {
         uint done = 0;
         var t0 = Utils.sync_tick ();
         var logged_pause = false;
+        string? transfer_error = null;
         while (done < job.uids.length) {
             if (this.high_refresh_waiters > 0) {
                 if (!logged_pause) {
@@ -2636,8 +2637,10 @@ public class Mail.MailSession : Camel.Session {
             for (uint i = done; i < end; i++)
                 batch.add (job.uids[i]);
 
-            for (uint i = 0; i < batch.length; i++)
-                yield capture_local_body (job.account, job.from, batch[i], source_folder);
+            if (job.delete_original) {
+                for (uint i = 0; i < batch.length; i++)
+                    yield capture_local_body (job.account, job.from, batch[i], source_folder);
+            }
 
 #if HAVE_CAMEL_3_58
             GenericArray<weak string>? transferred = null;
@@ -2655,15 +2658,13 @@ public class Mail.MailSession : Camel.Session {
                         null,
                         out transferred
                     );
-                    if (job.delete_original)
-                        yield source_folder.synchronize (true, Priority.LOW, null);
                 } finally {
                     leave_camel (false);
                 }
             } catch (Error e) {
                 warning ("Could not move messages: %s", e.message);
-                finish_transfer_job (job, done, e.message);
-                return;
+                transfer_error = e.message;
+                break;
             }
 
             for (uint i = 0; i < batch.length; i++) {
@@ -2671,21 +2672,24 @@ public class Mail.MailSession : Camel.Session {
                 if (transferred != null && i < transferred.length
                     && transferred[i] != null && transferred[i].length > 0)
                     new_uid = transferred[i];
-                rekey_body (job.account, job.from, batch[i], job.destination, new_uid);
+                if (job.delete_original)
+                    rekey_body (job.account, job.from, batch[i], job.destination, new_uid);
                 var message_index = done + i;
                 if (job.messages != null && message_index < job.messages.length) {
                     var message = job.messages[message_index];
                     if (message != null && new_uid != message.uid) {
-                        rekey_body (
-                            job.account,
-                            job.destination,
-                            message.uid,
-                            job.destination,
-                            new_uid
-                        );
+                        if (job.delete_original) {
+                            rekey_body (
+                                job.account,
+                                job.destination,
+                                message.uid,
+                                job.destination,
+                                new_uid
+                            );
+                        }
                         message.uid = new_uid;
                     }
-                    if (message != null && job.delete_original)
+                    if (message != null)
                         message.local_only = false;
                 }
             }
@@ -2703,6 +2707,30 @@ public class Mail.MailSession : Camel.Session {
 
             Idle.add (flush_folder_transfers.callback);
             yield;
+        }
+
+        /* COPY + \Deleted is the fallback when the server lacks UID MOVE.
+         * Complete all copies first, then upload/EXPUNGE the source flags once
+         * for the whole job instead of once per selected message. */
+        if (job.delete_original && done > 0) {
+            try {
+                yield enter_camel (false);
+                try {
+                    yield source_folder.synchronize (true, Priority.LOW, null);
+                } finally {
+                    leave_camel (false);
+                }
+            } catch (Error e) {
+                warning ("Could not expunge moved messages: %s", e.message);
+                transfer_error = transfer_error == null
+                    ? e.message
+                    : "%s; %s".printf (transfer_error, e.message);
+            }
+        }
+
+        if (transfer_error != null) {
+            finish_transfer_job (job, done, transfer_error);
+            return;
         }
 
         apply_camel_counts (job.from, source_folder);

--- a/src/mail-session.vala
+++ b/src/mail-session.vala
@@ -36,7 +36,15 @@ public class Mail.MailSession : Camel.Session {
     public signal void message_sent (Account account, Message? sent);
     public signal void draft_saved (Account account, Message? draft);
     public signal void draft_removed (Account account, Folder folder, string uid);
-    public signal void transfer_failed (Account account, Folder from, GenericArray<string> uids, string error);
+    public signal void transfer_completed (Account account, Folder from, Folder destination);
+    public signal void transfer_failed (
+        Account account,
+        Folder from,
+        Folder destination,
+        GenericArray<string> uids,
+        GenericArray<Message>? messages,
+        string error
+    );
 
     public MailSession (E.SourceRegistry registry) {
         var data = Path.build_filename (Environment.get_user_data_dir (), "letter", "mail");
@@ -677,7 +685,7 @@ public class Mail.MailSession : Camel.Session {
         for (uint i = 0; i < uids.length; i++) {
             var uid = uids[i];
             var info = camel_folder.get_message_info (uid);
-            if (info != null) {
+            if (info != null && !message_info_is_deleted (info)) {
                 var message = message_from_info (account, uid, info, folder, outgoing, camel_folder);
                 if (SearchQuery.matches_message (message, query))
                     messages.add (message);
@@ -763,6 +771,26 @@ public class Mail.MailSession : Camel.Session {
         camel_folder.free_uids (raw);
 #endif
         return uids;
+    }
+
+    private static bool message_info_is_deleted (Camel.MessageInfo? info) {
+        return info != null
+            && (info.get_flags () & Camel.MessageFlags.DELETED) != 0;
+    }
+
+    /* Camel keeps messages in its summary after \Deleted is set and removes
+     * them only after EXPUNGE. Never expose those pending-deletion entries as
+     * ordinary mail or include them in Letter's visible folder counts. */
+    private static GenericArray<string> folder_visible_uids (Camel.Folder camel_folder) {
+        var raw = folder_list_uids (camel_folder);
+        var visible = new GenericArray<string> ();
+        for (uint i = 0; i < raw.length; i++) {
+            var info = camel_folder.get_message_info (raw[i]);
+            if (info == null || message_info_is_deleted (info))
+                continue;
+            visible.add (raw[i]);
+        }
+        return visible;
     }
 
     private static GenericArray<string> folder_search_uids (
@@ -892,7 +920,7 @@ public class Mail.MailSession : Camel.Session {
             this.high_refresh_waiters--;
     }
 
-    private async void refresh_folder_info (Camel.Folder camel_folder, bool high) {
+    private async void refresh_folder_info (Camel.Folder camel_folder, bool high) throws Error {
         yield enter_camel (high);
         try {
             var name = camel_folder.get_full_display_name () ?? camel_folder.get_full_name ();
@@ -910,6 +938,7 @@ public class Mail.MailSession : Camel.Session {
         } catch (Error e) {
             Utils.sync_log ("Camel refresh_info FAILED: %s".printf (e.message));
             warning ("Could not refresh folder: %s", e.message);
+            throw e;
         } finally {
             leave_camel (high);
         }
@@ -1028,7 +1057,7 @@ public class Mail.MailSession : Camel.Session {
     }
 
     private static void apply_camel_counts (Folder folder, Camel.Folder camel_folder) {
-        var uids = folder_list_uids (camel_folder);
+        var uids = folder_visible_uids (camel_folder);
         int total = (int) uids.length;
         int unread = 0;
         for (uint i = 0; i < uids.length; i++) {
@@ -1051,7 +1080,7 @@ public class Mail.MailSession : Camel.Session {
             || folder.kind == FolderKind.DRAFTS
             || folder.kind == FolderKind.OUTBOX;
         var t0 = Utils.sync_tick ();
-        var uids = folder_list_uids (camel_folder);
+        var uids = folder_visible_uids (camel_folder);
         var total = uids.length;
         if (total >= 500) {
             Utils.sync_log ("collect_messages “%s” begin %u uids".printf (folder.name, total));
@@ -1107,7 +1136,7 @@ public class Mail.MailSession : Camel.Session {
     ) {
         added = 0;
         gone = 0;
-        var uids = folder_list_uids (camel_folder);
+        var uids = folder_visible_uids (camel_folder);
         var have = new HashTable<string, Message> (str_hash, str_equal);
         for (uint i = 0; i < previous.length; i++)
             have.set (previous[i].uid, previous[i]);
@@ -1669,7 +1698,7 @@ public class Mail.MailSession : Camel.Session {
             if (messages[i].is_placeholder)
                 continue;
             var info = watch.camel_folder.get_message_info (messages[i].uid);
-            if (info == null) {
+            if (info == null || message_info_is_deleted (info)) {
                 removed.add (messages[i].uid);
                 continue;
             }
@@ -1693,7 +1722,7 @@ public class Mail.MailSession : Camel.Session {
         var outgoing = folder.kind == FolderKind.SENT
             || folder.kind == FolderKind.DRAFTS
             || folder.kind == FolderKind.OUTBOX;
-        var uids = folder_list_uids (watch.camel_folder);
+        var uids = folder_visible_uids (watch.camel_folder);
         uint added = 0;
         for (uint i = 0; i < uids.length; i++) {
             if (have.contains (uids[i]))
@@ -2058,6 +2087,9 @@ public class Mail.MailSession : Camel.Session {
         yield enter_camel (true);
         try {
             yield source_folder.transfer_messages_to (uids, dest_folder, true, Priority.DEFAULT, cancellable, out transferred);
+            /* IMAP servers without UID MOVE implement this as COPY plus a
+             * local \Deleted flag. Push and expunge that source-side flag now. */
+            yield source_folder.synchronize (true, Priority.DEFAULT, cancellable);
         } finally {
             leave_camel (true);
         }
@@ -2121,6 +2153,9 @@ public class Mail.MailSession : Camel.Session {
             destination.name,
             uids.length
         ));
+        /* The undo window has already expired by the time this is called. Do
+         * not wait for the next periodic sync to make the server-side move. */
+        pump_transfer_flush.begin ();
     }
 
     /* Copy without removing from source (Gmail Important label). Deferred like moves. */
@@ -2151,16 +2186,29 @@ public class Mail.MailSession : Camel.Session {
             destination.name,
             uids.length
         ));
+        pump_transfer_flush.begin ();
     }
 
     /* Push deferred flag/move/copy jobs (call from sync-interval / manual refresh). */
-    public void flush_pending_local_changes () {
+    public async void flush_pending_local_changes () {
         if (this.flag_flush_queue.length > 0)
             Utils.sync_log ("flushing deferred flags (%u queue)".printf (this.flag_flush_queue.length));
         if (this.transfer_flush_queue.length > 0)
             Utils.sync_log ("flushing deferred transfers (%u queue)".printf (this.transfer_flush_queue.length));
         pump_flag_flush.begin ();
         pump_transfer_flush.begin ();
+
+        /* begin() is used during normal operation, but shutdown must be able
+         * to wait until both in-memory queues have actually drained. */
+        while (this.flag_flush_running || this.transfer_flush_running
+            || this.flag_flush_queue.length > 0 || this.transfer_flush_queue.length > 0) {
+            Timeout.add (50, flush_pending_local_changes.callback);
+            yield;
+            if (!this.flag_flush_running && this.flag_flush_queue.length > 0)
+                pump_flag_flush.begin ();
+            if (!this.transfer_flush_running && this.transfer_flush_queue.length > 0)
+                pump_transfer_flush.begin ();
+        }
     }
 
     public async void delete_message (Account account, Folder folder, string uid, Folder? trash, Cancellable? cancellable = null) throws Error {
@@ -2174,12 +2222,18 @@ public class Mail.MailSession : Camel.Session {
         try {
             yield enter_camel (true);
             try {
-                yield camel_folder.synchronize_message (uid, Priority.DEFAULT, cancellable);
+                /* Permanent delete is a flag upload followed by EXPUNGE.
+                 * synchronize_message() only downloads a body for offline use. */
+                yield camel_folder.synchronize (true, Priority.DEFAULT, cancellable);
             } finally {
                 leave_camel (true);
             }
         } catch (Error e) {
+            /* Keep the local summary usable when the server rejected the
+             * operation, and let the caller restore its optimistic UI state. */
+            camel_folder.set_message_flags (uid, Camel.MessageFlags.DELETED, 0);
             warning ("Could not expunge deleted message: %s", e.message);
+            throw e;
         }
         drop_body (account, folder, uid);
         apply_camel_counts (folder, camel_folder);
@@ -2209,8 +2263,25 @@ public class Mail.MailSession : Camel.Session {
         } finally {
             camel_folder.thaw ();
         }
+        try {
+            yield enter_camel (true);
+            try {
+                yield camel_folder.synchronize (true, Priority.DEFAULT, null);
+            } finally {
+                leave_camel (true);
+            }
+        } catch (Error e) {
+            camel_folder.freeze ();
+            try {
+                for (uint i = 0; i < uids.length; i++)
+                    camel_folder.set_message_flags (uids[i], Camel.MessageFlags.DELETED, 0);
+            } finally {
+                camel_folder.thaw ();
+            }
+            apply_camel_counts (folder, camel_folder);
+            throw e;
+        }
         apply_camel_counts (folder, camel_folder);
-        enqueue_flag_flush (account, folder, uids);
     }
 
     public async void empty_folder (Account account, Folder folder) throws Error {
@@ -2240,14 +2311,31 @@ public class Mail.MailSession : Camel.Session {
         } finally {
             camel_folder.thaw ();
         }
+        try {
+            yield enter_camel (true);
+            try {
+                yield camel_folder.synchronize (true, Priority.DEFAULT, null);
+            } finally {
+                leave_camel (true);
+            }
+        } catch (Error e) {
+            camel_folder.freeze ();
+            try {
+                for (uint i = 0; i < uids.length; i++)
+                    camel_folder.set_message_flags (uids[i], Camel.MessageFlags.DELETED, 0);
+            } finally {
+                camel_folder.thaw ();
+            }
+            apply_camel_counts (folder, camel_folder);
+            throw e;
+        }
         folder.unread = 0;
         folder.total = 0;
-        enqueue_flag_flush (account, folder, uids);
     }
 
     public async void set_folder_seen (Account account, Folder folder, bool seen) throws Error {
         var camel_folder = yield open_camel_folder (account, folder, null);
-        var raw = folder_list_uids (camel_folder);
+        var raw = folder_visible_uids (camel_folder);
         if (raw.length == 0)
             return;
 
@@ -2567,6 +2655,8 @@ public class Mail.MailSession : Camel.Session {
                         null,
                         out transferred
                     );
+                    if (job.delete_original)
+                        yield source_folder.synchronize (true, Priority.LOW, null);
                 } finally {
                     leave_camel (false);
                 }
@@ -2585,8 +2675,18 @@ public class Mail.MailSession : Camel.Session {
                 var message_index = done + i;
                 if (job.messages != null && message_index < job.messages.length) {
                     var message = job.messages[message_index];
-                    if (message != null && new_uid != message.uid)
+                    if (message != null && new_uid != message.uid) {
+                        rekey_body (
+                            job.account,
+                            job.destination,
+                            message.uid,
+                            job.destination,
+                            new_uid
+                        );
                         message.uid = new_uid;
+                    }
+                    if (message != null && job.delete_original)
+                        message.local_only = false;
                 }
             }
 
@@ -2610,6 +2710,7 @@ public class Mail.MailSession : Camel.Session {
         bump_transfer_pending (job.account, job.from, -1);
         if (job.from.full_name != job.destination.full_name)
             bump_transfer_pending (job.account, job.destination, -1);
+        this.transfer_completed (job.account, job.from, job.destination);
     }
 
     private void finish_transfer_job (TransferFlushJob job, uint done, string error) {
@@ -2620,7 +2721,20 @@ public class Mail.MailSession : Camel.Session {
         var remaining = new GenericArray<string> ();
         for (uint i = done; i < job.uids.length; i++)
             remaining.add (job.uids[i]);
-        this.transfer_failed (job.account, job.from, remaining, error);
+        GenericArray<Message>? remaining_messages = null;
+        if (job.messages != null) {
+            remaining_messages = new GenericArray<Message> ();
+            for (uint i = done; i < job.messages.length; i++)
+                remaining_messages.add (job.messages[i]);
+        }
+        this.transfer_failed (
+            job.account,
+            job.from,
+            job.destination,
+            remaining,
+            remaining_messages,
+            error
+        );
     }
 
     public async void create_mailbox_folder (Account account, Folder parent, string name) throws Error {

--- a/src/mail-session.vala
+++ b/src/mail-session.vala
@@ -598,8 +598,10 @@ public class Mail.MailSession : Camel.Session {
         if (watch)
             watch_camel_folder (account, folder, camel_folder);
 
+        var refreshed = false;
         if (refresh && !folder_has_pending_flags (account, folder)) {
             yield refresh_folder_info (camel_folder, high);
+            refreshed = true;
         }
 
         if (cancellable != null && cancellable.is_cancelled ())
@@ -652,7 +654,10 @@ public class Mail.MailSession : Camel.Session {
             ));
         }
 
-        resolve_pending_body_rekeys (account, folder, messages);
+        /* A local Camel summary may be stale or incomplete. Only bind an
+         * unknown no-COPYUID destination after a successful server refresh. */
+        if (refreshed)
+            resolve_pending_body_rekeys (account, folder, messages);
         messages = retain_local_only (account, folder, messages, previous);
         retain_pending_transfer_placeholders (account, folder, messages);
         Conversation.prune_duplicate_sends (messages);
@@ -670,14 +675,17 @@ public class Mail.MailSession : Camel.Session {
     public async GenericArray<Message> sync_headers (Account account, Folder folder) throws Error {
         var camel_folder = yield open_camel_folder (account, folder, null);
         watch_camel_folder (account, folder, camel_folder);
+        var refreshed = false;
         if (!folder_has_pending_flags (account, folder)) {
             yield refresh_folder_info (
                 camel_folder,
                 folder.kind == FolderKind.SENT || folder.kind == FolderKind.DRAFTS
             );
+            refreshed = true;
         }
         var messages = yield collect_messages (account, camel_folder, folder, null);
-        resolve_pending_body_rekeys (account, folder, messages);
+        if (refreshed)
+            resolve_pending_body_rekeys (account, folder, messages);
         retain_pending_transfer_placeholders (account, folder, messages);
         apply_counts_from_messages (folder, messages);
         return messages;
@@ -745,8 +753,9 @@ public class Mail.MailSession : Camel.Session {
         Cancellable? cancellable = null
     ) throws Error {
         var camel_folder = yield open_camel_folder (account, folder, cancellable);
-        if (!folder_has_pending_flags (account, folder))
-            yield refresh_folder_info (camel_folder, true);
+        if (folder_has_pending_flags (account, folder))
+            return null;
+        yield refresh_folder_info (camel_folder, true);
         var messages = yield collect_messages (account, camel_folder, folder, cancellable);
         return matching_message_uid (messages, candidate);
     }
@@ -1296,7 +1305,7 @@ public class Mail.MailSession : Camel.Session {
         return live;
     }
 
-    private void retain_pending_transfer_placeholders (
+    public void retain_pending_transfer_placeholders (
         Account account,
         Folder folder,
         GenericArray<Message> live
@@ -1370,10 +1379,9 @@ public class Mail.MailSession : Camel.Session {
                     && live[j].uid == pending.candidate.uid)
                     live.remove_index (j);
             }
+            pending.resolved_uid = replacement.uid;
             if (pending.body_path == null)
                 this.pending_body_rekeys.remove_index (i);
-            else
-                pending.resolved_uid = replacement.uid;
             changed = true;
         }
         if (changed)
@@ -1392,7 +1400,7 @@ public class Mail.MailSession : Camel.Session {
         return false;
     }
 
-    private PendingBodyRekey? resolved_body_rekey (
+    private PendingBodyRekey? pending_body_rekey (
         Account account,
         Folder folder,
         string uid
@@ -1402,7 +1410,7 @@ public class Mail.MailSession : Camel.Session {
             var pending = this.pending_body_rekeys[i];
             if (pending.account_key == account_key
                 && pending.destination.full_name == folder.full_name
-                && pending.resolved_uid == uid)
+                && (pending.resolved_uid == uid || pending.candidate.uid == uid))
                 return pending;
         }
         return null;
@@ -2007,7 +2015,6 @@ public class Mail.MailSession : Camel.Session {
 
         var before_prune = messages.length;
         Conversation.prune_duplicate_sends (messages);
-        resolve_pending_body_rekeys (account, folder, messages);
         if (added == 0 && messages.length == before_prune)
             return 0;
         if (added == 0)
@@ -2048,10 +2055,14 @@ public class Mail.MailSession : Camel.Session {
     }
 
     public async MessageContent load_message (Account account, Folder folder, string uid, Cancellable? cancellable = null) throws Error {
-        var key = body_key (account, folder, uid);
-        var cached = this.body_cache.get (key);
-        var pending = resolved_body_rekey (account, folder, uid);
-        if (cached != null && pending == null)
+        var requested_key = body_key (account, folder, uid);
+        var pending = pending_body_rekey (account, folder, uid);
+        var load_uid = pending != null && pending.resolved_uid != null
+            ? pending.resolved_uid
+            : uid;
+        var key = body_key (account, folder, load_uid);
+        var cached = this.body_cache.get (key) ?? this.body_cache.get (requested_key);
+        if (cached != null && (pending == null || pending.resolved_uid == null))
             return cached;
 
         var has_unresolved_rekey = folder_has_pending_body_rekeys (account, folder);
@@ -2060,15 +2071,30 @@ public class Mail.MailSession : Camel.Session {
         if (has_unresolved_rekey) {
             /* A singleton candidate cannot establish uniqueness: the folder
              * may already contain another message with the same Message-ID or
-             * fallback fingerprint. Resolve only against the complete summary. */
-            var live = yield collect_messages (account, camel_folder, folder, cancellable);
-            resolve_pending_body_rekeys (account, folder, live);
-            cached = this.body_cache.get (key);
-            pending = resolved_body_rekey (account, folder, uid);
-            if (pending != null)
-                defer_online = true;
+             * fallback fingerprint. Resolve only after a successful online
+             * refresh; an offline/local summary is not authoritative. */
+            try {
+                var requested_pending = pending;
+                camel_folder = yield open_camel_folder (account, folder, cancellable, true);
+                yield refresh_folder_info (camel_folder, true);
+                var live = yield collect_messages (account, camel_folder, folder, cancellable);
+                resolve_pending_body_rekeys (account, folder, live);
+                pending = pending_body_rekey (account, folder, uid);
+                if (pending == null && requested_pending != null
+                    && requested_pending.resolved_uid != null)
+                    pending = requested_pending;
+            } catch (Error e) {
+                if (cancellable != null && cancellable.is_cancelled ())
+                    throw e;
+                debug ("Could not refresh pending moved message %s: %s", uid, e.message);
+            }
+            load_uid = pending != null && pending.resolved_uid != null
+                ? pending.resolved_uid
+                : uid;
+            key = body_key (account, folder, load_uid);
+            cached = this.body_cache.get (key) ?? this.body_cache.get (requested_key);
         }
-        var mime = message_from_local_cache (camel_folder, uid);
+        var mime = message_from_local_cache (camel_folder, load_uid);
         var destination_cached = mime != null;
         if (destination_cached && pending != null) {
             finish_body_rekey (pending);
@@ -2092,17 +2118,22 @@ public class Mail.MailSession : Camel.Session {
                 }
             }
             if (mime != null)
-                Utils.sync_log ("open body “%s” uid=%s from moved disk cache".printf (folder.name, uid));
+                Utils.sync_log ("open body “%s” uid=%s from moved disk cache".printf (folder.name, load_uid));
         }
         if (mime == null) {
+            if (pending != null && pending.resolved_uid == null) {
+                throw new IOError.NOT_FOUND (
+                    _("This message is still syncing with the server. Try again in a moment.")
+                );
+            }
             if (defer_online)
                 camel_folder = yield open_camel_folder (account, folder, cancellable, true);
-            Utils.sync_log ("open body “%s” uid=%s from server".printf (folder.name, uid));
+            Utils.sync_log ("open body “%s” uid=%s from server".printf (folder.name, load_uid));
             try {
-                mime = yield fetch_camel_message (camel_folder, uid, Priority.DEFAULT);
-                destination_cached = message_from_local_cache (camel_folder, uid) != null;
+                mime = yield fetch_camel_message (camel_folder, load_uid, Priority.DEFAULT);
+                destination_cached = message_from_local_cache (camel_folder, load_uid) != null;
             } catch (Error e) {
-                mime = message_from_local_cache (camel_folder, uid);
+                mime = message_from_local_cache (camel_folder, load_uid);
                 destination_cached = mime != null;
                 if (mime == null) {
                     if (is_missing_on_server (e)) {
@@ -2120,7 +2151,7 @@ public class Mail.MailSession : Camel.Session {
             );
         }
 
-        var fetched = MessageContent.from_mime (uid, mime);
+        var fetched = MessageContent.from_mime (load_uid, mime);
         this.body_cache.set (key, fetched);
         if (pending != null && destination_cached)
             finish_body_rekey (pending);

--- a/src/message-window.vala
+++ b/src/message-window.vala
@@ -217,8 +217,21 @@ public class Mail.MessageWindow : Adw.ApplicationWindow {
                     yield this.session.copy_message (this.account, this.folder, this.message.uid, destination);
             } else {
                 var source = this.folder.kind == FolderKind.IMPORTANT ? this.folder : destination;
+                var uid = this.message.uid;
+                if (this.folder.kind != FolderKind.IMPORTANT) {
+                    uid = yield this.session.find_matching_uid (
+                        this.account,
+                        destination,
+                        this.message
+                    );
+                    if (uid == null) {
+                        throw new IOError.NOT_FOUND (
+                            _("This message is still syncing with the server. Try again in a moment.")
+                        );
+                    }
+                }
                 var uids = new GenericArray<string> ();
-                uids.add (this.message.uid);
+                uids.add (uid);
                 yield this.session.delete_uids (this.account, source, uids, null);
                 if (this.folder.kind == FolderKind.IMPORTANT) {
                     folder_changed ();

--- a/src/window.vala
+++ b/src/window.vala
@@ -5467,20 +5467,24 @@ public class Mail.Window : Adw.ApplicationWindow {
 
         try {
             yield this.mail_session.delete_message (account, folder, uid, null);
-            refresh_folder_badge (folder);
+            if (is_current_account (account))
+                refresh_folder_badge (folder);
             var cache = this.message_cache.get (message_cache_key (account, folder));
             if (cache != null)
                 save_header_list_cache_now (account, folder, cache);
         } catch (Error e) {
             this.hidden_uids.remove (hide_key (account, folder, uid));
             add_to_folder_cache (account, folder, message);
-            restore_to_search_results (message);
             var cache = this.message_cache.get (message_cache_key (account, folder));
             if (cache != null) {
                 sort_messages_by_date (cache);
                 save_header_list_cache_now (account, folder, cache);
             }
             restore_folder_counts_from_cache (account, folder);
+            if (!is_current_account (account))
+                return;
+
+            restore_to_search_results (message);
             refresh_folder_badge (folder);
             if (is_searching && this.search_results != null)
                 display_search_results (this.search_results);

--- a/src/window.vala
+++ b/src/window.vala
@@ -127,6 +127,7 @@ public class Mail.Window : Adw.ApplicationWindow {
     private bool tearing_down;
     private HashTable<string, uint8> hidden_uids;
     private PendingTransferUndo? pending_transfer_undo;
+    private uint64 transfer_placeholder_serial;
     private HashTable<string, uint8> collapsed_folders;
     private Gtk.SizeGroup account_header_sizes;
     private Gtk.SizeGroup account_row_sizes;
@@ -501,6 +502,7 @@ public class Mail.Window : Adw.ApplicationWindow {
             this.mail_session.message_sent.connect (on_message_sent);
             this.mail_session.draft_saved.connect (on_draft_saved);
             this.mail_session.draft_removed.connect (on_draft_removed);
+            this.mail_session.transfer_completed.connect (on_transfer_completed);
             this.mail_session.transfer_failed.connect (on_transfer_failed);
             bind_reader_mailbox ();
         }
@@ -1034,12 +1036,21 @@ public class Mail.Window : Adw.ApplicationWindow {
         enqueue_incoming_folder_sync (RANK_SELECTED_HEADERS);
         watch_new_mail_folders.begin ();
         schedule_folder_scout (3);
+        schedule_idle_bulk_align (true);
     }
 
     private void schedule_idle_bulk_align (bool from_startup) {
         stop_idle_bulk_align ();
-        if (from_startup)
-            Utils.sync_log ("idle bulk align: disabled (cache-first model)");
+        if (this.tearing_down || this.selected_account == null)
+            return;
+
+        var delay = from_startup ? IDLE_BULK_FIRST_SECONDS : IDLE_BULK_STEP_SECONDS;
+        this.idle_bulk_source = Timeout.add_seconds (delay, () => {
+            this.idle_bulk_source = 0;
+            try_idle_bulk_step ();
+            schedule_idle_bulk_align (false);
+            return Source.REMOVE;
+        });
     }
 
     private void stop_idle_bulk_align () {
@@ -1439,8 +1450,16 @@ public class Mail.Window : Adw.ApplicationWindow {
             return;
 
         if (job.kind == SYNC_KIND_HEADERS) {
-            if (this.mail_session.folder_has_pending_flags (account, folder))
+            if (this.mail_session.folder_has_pending_flags (account, folder)) {
+                /* The job was already removed from sync_jobs. Put it back after
+                 * the write-side queue gets a chance to finish instead of
+                 * silently losing this reconciliation cycle. */
+                Timeout.add (250, run_sync_job.callback);
+                yield;
+                if (!cancellable.is_cancelled () && is_current_account (account))
+                    enqueue_sync_job (SYNC_KIND_HEADERS, folder, job.rank);
                 return;
+            }
             var current = is_current_folder (folder);
             uint token = 0;
             if (current) {
@@ -2928,15 +2947,18 @@ public class Mail.Window : Adw.ApplicationWindow {
         }
         cached = this.message_cache.get (cache_key);
         if ((cached == null || cached.length == 0)
-            && (folder.total > 0 || folder.unread > 0 || hint_total > 0 || hint_unread > 0)
-            && !folder_is_incoming_watch (folder)
-            && !folder.is_gmail_namespace) {
+            && (folder.total > 0 || folder.unread > 0 || hint_total > 0 || hint_unread > 0)) {
             if (folder.total <= 0 && hint_total > 0)
                 folder.total = hint_total;
             if (folder.unread <= 0 && hint_unread > 0)
                 folder.unread = hint_unread;
-            boost_folder_sync (folder);
         }
+
+        /* Paint the cache first, then always verify the folder the user chose.
+         * Count-only scouting cannot detect equal-count UID replacement or
+         * remote flag changes in a warm non-Inbox cache. */
+        if (is_current_folder (folder))
+            boost_folder_sync (folder);
     }
 
     private void show_bookmarked_messages () {
@@ -3281,15 +3303,31 @@ public class Mail.Window : Adw.ApplicationWindow {
         return folder_is_bulk_storage (folder) || messages.length >= 200;
     }
 
+    private static bool header_list_cache_needs_update (
+        Account account,
+        Folder folder,
+        GenericArray<Message> messages
+    ) {
+        if (header_list_cache_worth_saving (folder, messages))
+            return true;
+
+        /* Once a folder has a disk cache, keep updating it even after deletes
+         * take the list below the normal persistence threshold. Otherwise an
+         * old, larger snapshot can resurrect removed messages on restart. */
+        var account_uid = account.source_uid ?? account.uid;
+        var path = MailSession.header_list_cache_file (account_uid, folder.full_name);
+        return FileUtils.test (path, FileTest.IS_REGULAR);
+    }
+
     private void queue_header_list_cache_save (
         Account account,
         Folder folder,
         GenericArray<Message> messages
     ) {
-        if (!header_list_cache_worth_saving (folder, messages))
-            return;
         var key = message_cache_key (account, folder);
         var existing = this.header_cache_save_sources.get (key);
+        if (!header_list_cache_needs_update (account, folder, messages) && existing == 0)
+            return;
         if (existing != 0)
             Source.remove (existing);
 
@@ -3307,6 +3345,28 @@ public class Mail.Window : Adw.ApplicationWindow {
             return Source.REMOVE;
         });
         this.header_cache_save_sources.set (key, source);
+    }
+
+    private void save_header_list_cache_now (
+        Account account,
+        Folder folder,
+        GenericArray<Message> messages
+    ) {
+        var key = message_cache_key (account, folder);
+        var pending = this.header_cache_save_sources.get (key);
+        if (!header_list_cache_needs_update (account, folder, messages) && pending == 0)
+            return;
+        if (pending != 0) {
+            Source.remove (pending);
+            this.header_cache_save_sources.remove (key);
+        }
+
+        save_header_list_cache (
+            account.source_uid ?? account.uid,
+            folder.full_name,
+            folder.name,
+            messages
+        );
     }
 
     private static GenericArray<Message>? load_header_list_cache (Account account, Folder folder) {
@@ -3938,6 +3998,7 @@ public class Mail.Window : Adw.ApplicationWindow {
         refresh_folder_badge (folder);
         sync_bookmarks_folder ();
         sync_important_markers ();
+        queue_header_list_cache_save (account, folder, cache);
         if (is_current_folder (folder) && this.search_text.length == 0) {
             if (added > 0 || removed.length > 0)
                 display_messages (account, folder, cache);
@@ -5359,6 +5420,9 @@ public class Mail.Window : Adw.ApplicationWindow {
         try {
             yield this.mail_session.delete_message (account, folder, uid, null);
             refresh_folder_badge (folder);
+            var cache = this.message_cache.get (message_cache_key (account, folder));
+            if (cache != null)
+                save_header_list_cache_now (account, folder, cache);
         } catch (Error e) {
             this.hidden_uids.remove (hide_key (account, folder, uid));
             this.toast_overlay.add_toast (new Adw.Toast (e.message) {
@@ -5473,7 +5537,12 @@ public class Mail.Window : Adw.ApplicationWindow {
                     try {
                         this.mail_session.delete_uids.end (res);
                         refresh_folder_badge (folder);
+                        var cache = this.message_cache.get (message_cache_key (account, folder));
+                        if (cache != null)
+                            save_header_list_cache_now (account, folder, cache);
                     } catch (Error e) {
+                        for (uint j = 0; j < uids.length; j++)
+                            this.hidden_uids.remove (hide_key (account, folder, uids[j]));
                         this.toast_overlay.add_toast (new Adw.Toast (e.message) {
                             timeout = 4,
                         });
@@ -5827,9 +5896,13 @@ public class Mail.Window : Adw.ApplicationWindow {
             from.total--;
         if (unseen && from.unread > 0)
             from.unread--;
-        Conversation.apply_folder (message, destination, null);
+        /* UIDs are scoped to a folder. Keeping the source UID in the
+         * destination can collide with an unrelated destination message. */
+        this.transfer_placeholder_serial++;
+        var placeholder_uid = "local-move-%llu".printf (this.transfer_placeholder_serial);
+        Conversation.apply_folder (message, destination, placeholder_uid);
         message.local_only = true;
-        this.mail_session.rekey_body (account, from, old_uid, destination, old_uid);
+        this.mail_session.rekey_body (account, from, old_uid, destination, placeholder_uid);
         add_to_folder_cache (account, destination, message);
         destination.total++;
         if (unseen)
@@ -5931,13 +6004,66 @@ public class Mail.Window : Adw.ApplicationWindow {
         }
     }
 
-    private void on_transfer_failed (Account account, Folder from, GenericArray<string> uids, string error) {
+    private void on_transfer_completed (Account account, Folder from, Folder destination) {
+        var source_cache = this.message_cache.get (message_cache_key (account, from));
+        if (source_cache != null)
+            save_header_list_cache_now (account, from, source_cache);
+        var destination_cache = this.message_cache.get (message_cache_key (account, destination));
+        if (destination_cache != null)
+            save_header_list_cache_now (account, destination, destination_cache);
+
+        if (!is_current_account (account))
+            return;
+
+        /* Confirm both UID namespaces after the backend has assigned the real
+         * destination UID and removed the source message. */
+        enqueue_sync_job (SYNC_KIND_HEADERS, from, RANK_SELECTED_HEADERS);
+        if (from.full_name != destination.full_name && destination_cache != null)
+            enqueue_sync_job (SYNC_KIND_HEADERS, destination, RANK_SELECTED_HEADERS);
+        pump_sync.begin ();
+    }
+
+    private void on_transfer_failed (
+        Account account,
+        Folder from,
+        Folder destination,
+        GenericArray<string> uids,
+        GenericArray<Message>? messages,
+        string error
+    ) {
         for (uint i = 0; i < uids.length; i++)
             this.hidden_uids.remove (hide_key (account, from, uids[i]));
+
+        /* Drop the optimistic destination placeholders. The source cache is
+         * rebuilt from Camel below, where the originals still exist. */
+        var destination_cache = this.message_cache.get (message_cache_key (account, destination));
+        if (messages != null) {
+            for (uint i = 0; i < messages.length; i++) {
+                if (i < uids.length) {
+                    this.mail_session.rekey_body (
+                        account,
+                        destination,
+                        messages[i].uid,
+                        from,
+                        uids[i]
+                    );
+                }
+                remove_from_folder_cache (account, destination, messages[i].uid);
+                remove_from_search_results (messages[i].uid, destination.full_name);
+            }
+        }
+        restore_folder_counts_from_cache (account, destination);
+        refresh_folder_badge (destination);
         this.toast_overlay.add_toast (new Adw.Toast (error) {
             timeout = 4,
         });
-        refresh_open_folder.begin (true, false);
+
+        if (!is_current_account (account))
+            return;
+        enqueue_sync_job (SYNC_KIND_HEADERS, from, RANK_SELECTED_HEADERS);
+        if (from.full_name != destination.full_name && destination_cache != null)
+            enqueue_sync_job (SYNC_KIND_HEADERS, destination, RANK_SELECTED_HEADERS);
+        pump_sync.begin ();
     }
 
     private Folder? find_archive_folder () {
@@ -6716,7 +6842,13 @@ public class Mail.Window : Adw.ApplicationWindow {
         try {
             yield this.mail_session.empty_folder (account, folder);
             refresh_folder_badge (folder);
+            var empty = this.message_cache.get (key) ?? new GenericArray<Message> ();
+            save_header_list_cache_now (account, folder, empty);
         } catch (Error e) {
+            if (cache != null) {
+                for (uint i = 0; i < cache.length; i++)
+                    this.hidden_uids.remove (hide_key (account, folder, cache[i].uid));
+            }
             this.toast_overlay.add_toast (new Adw.Toast (e.message) {
                 timeout = 5,
             });
@@ -7372,7 +7504,7 @@ public class Mail.Window : Adw.ApplicationWindow {
 
         /* Push local flag/move/copy changes before asking the server for new mail. */
         commit_pending_transfer_undo ();
-        this.mail_session.flush_pending_local_changes ();
+        this.mail_session.flush_pending_local_changes.begin ();
 
         var full_due = force_tree || this.last_full_align == 0
             || (Utils.sync_tick () - this.last_full_align) >= (int64) FULL_ALIGN_SECONDS * 1000 * 1000;
@@ -7566,6 +7698,12 @@ public class Mail.Window : Adw.ApplicationWindow {
         return false;
     }
 
+    public async void prepare_to_close () {
+        commit_pending_transfer_undo ();
+        if (this.mail_session != null)
+            yield this.mail_session.flush_pending_local_changes ();
+    }
+
     private void persist_window_state () {
         this.settings.set_int ("window-width", get_width ().clamp (WINDOW_MIN_WIDTH, 4000));
         this.settings.set_int ("window-height", get_height ().clamp (WINDOW_MIN_HEIGHT, 4000));
@@ -7581,7 +7719,8 @@ public class Mail.Window : Adw.ApplicationWindow {
         this.tearing_down = true;
 
         commit_pending_transfer_undo ();
-        this.mail_session?.flush_pending_local_changes ();
+        if (this.mail_session != null)
+            this.mail_session.flush_pending_local_changes.begin ();
 
         if (this.sync_source != 0) {
             Source.remove (this.sync_source);
@@ -7612,6 +7751,7 @@ public class Mail.Window : Adw.ApplicationWindow {
             this.mail_session.message_sent.disconnect (on_message_sent);
             this.mail_session.draft_saved.disconnect (on_draft_saved);
             this.mail_session.draft_removed.disconnect (on_draft_removed);
+            this.mail_session.transfer_completed.disconnect (on_transfer_completed);
             this.mail_session.transfer_failed.disconnect (on_transfer_failed);
         }
     }

--- a/src/window.vala
+++ b/src/window.vala
@@ -502,6 +502,7 @@ public class Mail.Window : Adw.ApplicationWindow {
             this.mail_session.message_sent.connect (on_message_sent);
             this.mail_session.draft_saved.connect (on_draft_saved);
             this.mail_session.draft_removed.connect (on_draft_removed);
+            this.mail_session.folder_flags_flushed.connect (on_folder_flags_flushed);
             this.mail_session.transfer_completed.connect (on_transfer_completed);
             this.mail_session.transfer_failed.connect (on_transfer_failed);
             bind_reader_mailbox ();
@@ -1451,13 +1452,9 @@ public class Mail.Window : Adw.ApplicationWindow {
 
         if (job.kind == SYNC_KIND_HEADERS) {
             if (this.mail_session.folder_has_pending_flags (account, folder)) {
-                /* The job was already removed from sync_jobs. Put it back after
-                 * the write-side queue gets a chance to finish instead of
-                 * silently losing this reconciliation cycle. */
-                Timeout.add (250, run_sync_job.callback);
-                yield;
-                if (!cancellable.is_cancelled () && is_current_account (account))
-                    enqueue_sync_job (SYNC_KIND_HEADERS, folder, job.rank);
+                /* Transfer/flag completion signals enqueue reconciliation.
+                 * Do not spin the sync pump while an EXPUNGE retry is waiting. */
+                Utils.sync_log ("headers “%s” deferred for pending local writes".printf (folder.name));
                 return;
             }
             var current = is_current_folder (folder);
@@ -6055,6 +6052,17 @@ public class Mail.Window : Adw.ApplicationWindow {
         pump_sync.begin ();
     }
 
+    private void on_folder_flags_flushed (Account account, Folder folder) {
+        if (!is_current_account (account))
+            return;
+        enqueue_sync_job (
+            SYNC_KIND_HEADERS,
+            folder,
+            is_current_folder (folder) ? RANK_SELECTED_HEADERS : background_header_rank (folder)
+        );
+        pump_sync.begin ();
+    }
+
     private void on_transfer_failed (
         Account account,
         Folder from,
@@ -7796,6 +7804,7 @@ public class Mail.Window : Adw.ApplicationWindow {
             this.mail_session.message_sent.disconnect (on_message_sent);
             this.mail_session.draft_saved.disconnect (on_draft_saved);
             this.mail_session.draft_removed.disconnect (on_draft_removed);
+            this.mail_session.folder_flags_flushed.disconnect (on_folder_flags_flushed);
             this.mail_session.transfer_completed.disconnect (on_transfer_completed);
             this.mail_session.transfer_failed.disconnect (on_transfer_failed);
         }

--- a/src/window.vala
+++ b/src/window.vala
@@ -6201,14 +6201,27 @@ public class Mail.Window : Adw.ApplicationWindow {
         restore_folder_counts_from_cache (account, from);
         restore_folder_counts_from_cache (account, destination);
         var source_cache = this.message_cache.get (message_cache_key (account, from));
-        if (failed_copy && source_cache != null) {
+        if (failed_copy) {
             /* These source UIDs were marked Important only for copies that
              * just failed. Clear the optimistic state before persisting, even
              * if the user switched accounts while the request was running. */
-            for (uint i = 0; i < uids.length; i++) {
-                for (uint j = 0; j < source_cache.length; j++) {
-                    if (source_cache[j].uid == uids[i])
-                        source_cache[j].important = false;
+            var failed_uids = new HashTable<string, uint8> (str_hash, str_equal);
+            for (uint i = 0; i < uids.length; i++)
+                failed_uids.set (uids[i], 1);
+            if (source_cache != null) {
+                for (uint i = 0; i < source_cache.length; i++) {
+                    if (failed_uids.contains (source_cache[i].uid))
+                        source_cache[i].important = false;
+                }
+            }
+            /* Global search can return messages without hydrating their source
+             * folder cache. Reset those live objects explicitly as well. */
+            if (current && this.search_results != null) {
+                for (uint i = 0; i < this.search_results.length; i++) {
+                    var result = this.search_results[i];
+                    if ((result.folder_full_name ?? "") == from.full_name
+                        && failed_uids.contains (result.uid))
+                        result.important = false;
                 }
             }
             if (current)

--- a/src/window.vala
+++ b/src/window.vala
@@ -5573,31 +5573,44 @@ public class Mail.Window : Adw.ApplicationWindow {
         else
             finish_conversation_bulk ();
 
-        for (uint i = 0; i < groups.length; i++) {
-            var folder = groups[i].folder;
-            var uids = groups[i].uids;
-            this.mail_session.delete_uids.begin (
-                account,
-                folder,
-                uids,
-                null,
-                (obj, res) => {
-                    try {
-                        this.mail_session.delete_uids.end (res);
-                        refresh_folder_badge (folder);
-                        var cache = this.message_cache.get (message_cache_key (account, folder));
-                        if (cache != null)
-                            save_header_list_cache_now (account, folder, cache);
-                    } catch (Error e) {
-                        for (uint j = 0; j < uids.length; j++)
-                            this.hidden_uids.remove (hide_key (account, folder, uids[j]));
-                        this.toast_overlay.add_toast (new Adw.Toast (e.message) {
-                            timeout = 4,
-                        });
-                        refresh_open_folder.begin (true, false);
-                    }
-                }
-            );
+        for (uint i = 0; i < groups.length; i++)
+            delete_message_group.begin (account, groups[i]);
+    }
+
+    private async void delete_message_group (Account account, FolderMessageGroup group) {
+        if (this.mail_session == null)
+            return;
+        var folder = group.folder;
+        try {
+            yield this.mail_session.delete_uids (account, folder, group.uids, null);
+            refresh_folder_badge (folder);
+            var cache = this.message_cache.get (message_cache_key (account, folder));
+            if (cache != null)
+                save_header_list_cache_now (account, folder, cache);
+        } catch (Error e) {
+            for (uint i = 0; i < group.uids.length; i++)
+                this.hidden_uids.remove (hide_key (account, folder, group.uids[i]));
+            for (uint i = 0; i < group.messages.length; i++) {
+                add_to_folder_cache (account, folder, group.messages[i]);
+                restore_to_search_results (group.messages[i]);
+            }
+            var cache = this.message_cache.get (message_cache_key (account, folder));
+            if (cache != null) {
+                sort_messages_by_date (cache);
+                save_header_list_cache_now (account, folder, cache);
+            }
+            restore_folder_counts_from_cache (account, folder);
+            refresh_folder_badge (folder);
+
+            if (is_current_account (account)) {
+                if (is_searching && this.search_results != null)
+                    display_search_results (this.search_results);
+                else
+                    redisplay_current_list ();
+                this.toast_overlay.add_toast (new Adw.Toast (e.message) {
+                    timeout = 4,
+                });
+            }
         }
     }
 

--- a/src/window.vala
+++ b/src/window.vala
@@ -3366,28 +3366,33 @@ public class Mail.Window : Adw.ApplicationWindow {
         );
     }
 
-    private static GenericArray<Message>? load_header_list_cache (Account account, Folder folder) {
+    private GenericArray<Message>? load_header_list_cache (Account account, Folder folder) {
+        var messages = new GenericArray<Message> ();
         var account_uid = account.source_uid ?? account.uid;
         var path = MailSession.header_list_cache_file (account_uid, folder.full_name);
-        if (!FileUtils.test (path, FileTest.IS_REGULAR))
-            return null;
+        if (!FileUtils.test (path, FileTest.IS_REGULAR)) {
+            this.mail_session?.retain_pending_transfer_placeholders (account, folder, messages);
+            return messages.length > 0 ? messages : null;
+        }
 
         string contents;
         try {
             FileUtils.get_contents (path, out contents);
         } catch (Error e) {
             debug ("Could not read header list cache: %s", e.message);
-            return null;
+            this.mail_session?.retain_pending_transfer_placeholders (account, folder, messages);
+            return messages.length > 0 ? messages : null;
         }
 
         var lines = contents.split ("\n");
-        if (lines.length < 2 || lines[0] != "letter-headers-v1")
-            return null;
+        if (lines.length < 2 || lines[0] != "letter-headers-v1") {
+            this.mail_session?.retain_pending_transfer_placeholders (account, folder, messages);
+            return messages.length > 0 ? messages : null;
+        }
 
         var outgoing = folder.kind == FolderKind.SENT
             || folder.kind == FolderKind.DRAFTS
             || folder.kind == FolderKind.OUTBOX;
-        var messages = new GenericArray<Message> ();
         for (int i = 1; i < lines.length; i++) {
             var line = lines[i];
             if (line.length == 0)
@@ -3448,9 +3453,8 @@ public class Mail.Window : Adw.ApplicationWindow {
             });
         }
 
-        if (messages.length == 0)
-            return null;
-        return messages;
+        this.mail_session?.retain_pending_transfer_placeholders (account, folder, messages);
+        return messages.length > 0 ? messages : null;
     }
 
     private static void save_header_list_cache (
@@ -5160,9 +5164,9 @@ public class Mail.Window : Adw.ApplicationWindow {
             }
             source.important = true;
             restore_folder_counts_from_cache (account, destination);
-            refresh_folder_badge (destination);
 
             if (is_current_account (account)) {
+                refresh_folder_badge (destination);
                 sync_important_markers ();
                 source.important = true;
                 this.open_conversation?.refresh ();

--- a/src/window.vala
+++ b/src/window.vala
@@ -5102,22 +5102,23 @@ public class Mail.Window : Adw.ApplicationWindow {
                     : find_important_uid (message);
                 if (uid == null)
                     continue;
+                Message? removed_copy = null;
                 for (uint j = 0; j < dest_cache.length; j++) {
                     if (dest_cache[j].uid != uid
                         && !(message.msgid_hash != 0 && dest_cache[j].msgid_hash == message.msgid_hash))
                         continue;
+                    removed_copy = dest_cache[j];
                     dest_cache.remove_index (j);
                     break;
                 }
-                var uids = new GenericArray<string> ();
-                uids.add (uid);
-                this.mail_session.delete_uids.begin (account, destination, uids, null, (obj, res) => {
-                    try {
-                        this.mail_session.delete_uids.end (res);
-                    } catch (Error e) {
-                        debug ("Could not clear Important: %s", e.message);
-                    }
-                });
+                delete_important_copy.begin (
+                    account,
+                    folder,
+                    message,
+                    destination,
+                    uid,
+                    removed_copy
+                );
                 if (this.selected_folder != null && this.selected_folder.kind == FolderKind.IMPORTANT)
                     remove_message_from_list (message.uid, message.folder_full_name);
             }
@@ -5135,6 +5136,54 @@ public class Mail.Window : Adw.ApplicationWindow {
         refresh_folder_badge (destination);
         queue_header_list_cache_save (account, destination, dest_cache);
         sync_important_markers ();
+    }
+
+    private async void delete_important_copy (
+        Account account,
+        Folder source_folder,
+        Message source,
+        Folder destination,
+        string uid,
+        Message? removed_copy
+    ) {
+        if (this.mail_session == null)
+            return;
+        var uids = new GenericArray<string> ();
+        uids.add (uid);
+        try {
+            yield this.mail_session.delete_uids (account, destination, uids, null);
+        } catch (Error e) {
+            debug ("Could not clear Important: %s", e.message);
+            if (removed_copy != null) {
+                removed_copy.important = true;
+                add_to_folder_cache (account, destination, removed_copy);
+            }
+            source.important = true;
+            restore_folder_counts_from_cache (account, destination);
+            refresh_folder_badge (destination);
+
+            if (is_current_account (account)) {
+                sync_important_markers ();
+                source.important = true;
+                this.open_conversation?.refresh ();
+                refresh_thread_rows ();
+                update_message_actions ();
+                if (is_searching && this.search_results != null)
+                    display_search_results (this.search_results);
+                else
+                    redisplay_current_list ();
+                this.toast_overlay.add_toast (new Adw.Toast (e.message) {
+                    timeout = 4,
+                });
+            }
+
+            var source_cache = this.message_cache.get (message_cache_key (account, source_folder));
+            if (source_cache != null)
+                save_header_list_cache_now (account, source_folder, source_cache);
+            var destination_cache = this.message_cache.get (message_cache_key (account, destination));
+            if (destination_cache != null)
+                save_header_list_cache_now (account, destination, destination_cache);
+        }
     }
 
     private Folder? find_important_copy (Message message) {
@@ -6928,9 +6977,13 @@ public class Mail.Window : Adw.ApplicationWindow {
             save_header_list_cache_now (account, folder, empty);
         } catch (Error e) {
             if (cache != null) {
+                this.message_cache.set (key, cache);
                 for (uint i = 0; i < cache.length; i++)
                     this.hidden_uids.remove (hide_key (account, folder, cache[i].uid));
+                restore_folder_counts_from_cache (account, folder);
             }
+            refresh_folder_badge (folder);
+            sync_bookmarks_folder ();
             this.toast_overlay.add_toast (new Adw.Toast (e.message) {
                 timeout = 5,
             });

--- a/src/window.vala
+++ b/src/window.vala
@@ -5090,12 +5090,14 @@ public class Mail.Window : Adw.ApplicationWindow {
             if (important) {
                 if (folder.kind == FolderKind.IMPORTANT)
                     continue;
-                if (find_important_uid (message) == null)
-                    dest_cache.add (message);
+                if (find_important_uid (message) != null)
+                    continue;
+                var destination_copy = make_local_copy (message, destination);
+                dest_cache.add (destination_copy);
                 var uids = new GenericArray<string> ();
                 uids.add (message.uid);
                 var copies = new GenericArray<Message> ();
-                copies.add (message);
+                copies.add (destination_copy);
                 this.mail_session.enqueue_copy_messages (account, folder, destination, uids, copies);
             } else {
                 var uid = folder.kind == FolderKind.IMPORTANT
@@ -5909,6 +5911,35 @@ public class Mail.Window : Adw.ApplicationWindow {
             destination.unread++;
     }
 
+    private Message make_local_copy (Message source, Folder destination) {
+        this.transfer_placeholder_serial++;
+        return new Message () {
+            uid = "local-copy-%llu".printf (this.transfer_placeholder_serial),
+            subject = source.subject,
+            from = source.from,
+            to = source.to,
+            cc = source.cc,
+            from_blob = source.from_blob,
+            to_blob = source.to_blob,
+            list_address = source.list_address,
+            date = source.date,
+            seen = source.seen,
+            flagged = source.flagged,
+            important = true,
+            has_attachment = source.has_attachment,
+            preview = source.preview,
+            folder_name = destination.name,
+            folder_full_name = destination.full_name,
+            show_folder = source.show_folder,
+            outgoing = source.outgoing,
+            msgid_hash = source.msgid_hash,
+            msgid_refs = source.msgid_refs,
+            conversation_key = source.conversation_key,
+            search_blob = source.search_blob,
+            local_only = true,
+        };
+    }
+
     private void drop_conversations (GenericArray<Conversation> conversations) {
         if (conversations.length == 0) {
             this.message_selection.unselect_all ();
@@ -6037,8 +6068,11 @@ public class Mail.Window : Adw.ApplicationWindow {
         /* Drop the optimistic destination placeholders. The source cache is
          * rebuilt from Camel below, where the originals still exist. */
         var destination_cache = this.message_cache.get (message_cache_key (account, destination));
+        var failed_copy = false;
         if (messages != null) {
             for (uint i = 0; i < messages.length; i++) {
+                if (messages[i].uid.has_prefix ("local-copy-"))
+                    failed_copy = true;
                 if (i < uids.length) {
                     this.mail_session.rekey_body (
                         account,
@@ -6060,6 +6094,16 @@ public class Mail.Window : Adw.ApplicationWindow {
 
         if (!is_current_account (account))
             return;
+        if (failed_copy) {
+            /* Removing a failed Gmail Important copy also clears the
+             * optimistic marker on its source message and persisted caches. */
+            sync_important_markers ();
+            var source_cache = this.message_cache.get (message_cache_key (account, from));
+            if (source_cache != null)
+                save_header_list_cache_now (account, from, source_cache);
+            if (destination_cache != null)
+                save_header_list_cache_now (account, destination, destination_cache);
+        }
         enqueue_sync_job (SYNC_KIND_HEADERS, from, RANK_SELECTED_HEADERS);
         if (from.full_name != destination.full_name && destination_cache != null)
             enqueue_sync_job (SYNC_KIND_HEADERS, destination, RANK_SELECTED_HEADERS);

--- a/src/window.vala
+++ b/src/window.vala
@@ -5599,34 +5599,36 @@ public class Mail.Window : Adw.ApplicationWindow {
         var folder = group.folder;
         try {
             yield this.mail_session.delete_uids (account, folder, group.uids, null);
-            refresh_folder_badge (folder);
+            if (is_current_account (account))
+                refresh_folder_badge (folder);
             var cache = this.message_cache.get (message_cache_key (account, folder));
             if (cache != null)
                 save_header_list_cache_now (account, folder, cache);
         } catch (Error e) {
             for (uint i = 0; i < group.uids.length; i++)
                 this.hidden_uids.remove (hide_key (account, folder, group.uids[i]));
-            for (uint i = 0; i < group.messages.length; i++) {
+            for (uint i = 0; i < group.messages.length; i++)
                 add_to_folder_cache (account, folder, group.messages[i]);
-                restore_to_search_results (group.messages[i]);
-            }
             var cache = this.message_cache.get (message_cache_key (account, folder));
             if (cache != null) {
                 sort_messages_by_date (cache);
                 save_header_list_cache_now (account, folder, cache);
             }
             restore_folder_counts_from_cache (account, folder);
+            if (!is_current_account (account))
+                return;
+
+            for (uint i = 0; i < group.messages.length; i++)
+                restore_to_search_results (group.messages[i]);
             refresh_folder_badge (folder);
 
-            if (is_current_account (account)) {
-                if (is_searching && this.search_results != null)
-                    display_search_results (this.search_results);
-                else
-                    redisplay_current_list ();
-                this.toast_overlay.add_toast (new Adw.Toast (e.message) {
-                    timeout = 4,
-                });
-            }
+            if (is_searching && this.search_results != null)
+                display_search_results (this.search_results);
+            else
+                redisplay_current_list ();
+            this.toast_overlay.add_toast (new Adw.Toast (e.message) {
+                timeout = 4,
+            });
         }
     }
 
@@ -6163,6 +6165,7 @@ public class Mail.Window : Adw.ApplicationWindow {
         GenericArray<Message>? messages,
         string error
     ) {
+        var current = is_current_account (account);
         for (uint i = 0; i < uids.length; i++)
             this.hidden_uids.remove (hide_key (account, from, uids[i]));
 
@@ -6189,33 +6192,35 @@ public class Mail.Window : Adw.ApplicationWindow {
                         Conversation.apply_folder (message, from, uids[i]);
                         message.local_only = false;
                         add_to_folder_cache (account, from, message);
-                        restore_to_search_results (message);
+                        if (current)
+                            restore_to_search_results (message);
                     }
                 }
                 remove_from_folder_cache (account, destination, placeholder_uid);
-                remove_from_search_results (placeholder_uid, destination.full_name);
+                if (current)
+                    remove_from_search_results (placeholder_uid, destination.full_name);
             }
         }
         restore_folder_counts_from_cache (account, from);
         restore_folder_counts_from_cache (account, destination);
-        refresh_folder_badge (from);
-        refresh_folder_badge (destination);
-        this.toast_overlay.add_toast (new Adw.Toast (error) {
-            timeout = 4,
-        });
-
-        if (!is_current_account (account))
-            return;
-        if (failed_copy) {
-            /* Removing a failed Gmail Important copy also clears the
-             * optimistic marker on its source message and persisted caches. */
-            sync_important_markers ();
-        }
         var source_cache = this.message_cache.get (message_cache_key (account, from));
         if (source_cache != null)
             save_header_list_cache_now (account, from, source_cache);
         if (destination_cache != null)
             save_header_list_cache_now (account, destination, destination_cache);
+        if (!current)
+            return;
+
+        refresh_folder_badge (from);
+        refresh_folder_badge (destination);
+        this.toast_overlay.add_toast (new Adw.Toast (error) {
+            timeout = 4,
+        });
+        if (failed_copy) {
+            /* Removing a failed Gmail Important copy also clears the
+             * optimistic marker on its source message and persisted caches. */
+            sync_important_markers ();
+        }
         if (is_searching && this.search_results != null)
             display_search_results (this.search_results);
         else
@@ -7001,7 +7006,8 @@ public class Mail.Window : Adw.ApplicationWindow {
 
         try {
             yield this.mail_session.empty_folder (account, folder);
-            refresh_folder_badge (folder);
+            if (is_current_account (account))
+                refresh_folder_badge (folder);
             var empty = this.message_cache.get (key) ?? new GenericArray<Message> ();
             save_header_list_cache_now (account, folder, empty);
         } catch (Error e) {
@@ -7011,6 +7017,9 @@ public class Mail.Window : Adw.ApplicationWindow {
                     this.hidden_uids.remove (hide_key (account, folder, cache[i].uid));
                 restore_folder_counts_from_cache (account, folder);
             }
+            if (!is_current_account (account))
+                return;
+
             refresh_folder_badge (folder);
             sync_bookmarks_folder ();
             this.toast_overlay.add_toast (new Adw.Toast (e.message) {

--- a/src/window.vala
+++ b/src/window.vala
@@ -5099,7 +5099,19 @@ public class Mail.Window : Adw.ApplicationWindow {
                 uids.add (message.uid);
                 var copies = new GenericArray<Message> ();
                 copies.add (destination_copy);
-                this.mail_session.enqueue_copy_messages (account, folder, destination, uids, copies);
+                var count_changes = new GenericArray<TransferCountChange> ();
+                count_changes.add (new TransferCountChange () {
+                    destination_total_incremented = true,
+                    destination_unread_incremented = !destination_copy.seen,
+                });
+                this.mail_session.enqueue_copy_messages (
+                    account,
+                    folder,
+                    destination,
+                    uids,
+                    copies,
+                    count_changes
+                );
             } else {
                 var uid = folder.kind == FolderKind.IMPORTANT
                     ? message.uid
@@ -5460,6 +5472,8 @@ public class Mail.Window : Adw.ApplicationWindow {
 
         var uid = message.uid;
         var unseen = !message.seen;
+        var previous_total = folder.total;
+        var previous_unread = folder.unread;
         hide_message (account, folder, uid, unseen);
 
         try {
@@ -5477,7 +5491,8 @@ public class Mail.Window : Adw.ApplicationWindow {
                 sort_messages_by_date (cache);
                 save_header_list_cache_now (account, folder, cache);
             }
-            restore_folder_counts_from_cache (account, folder);
+            folder.total = previous_total;
+            folder.unread = previous_unread;
             if (!is_current_account (account))
                 return;
 
@@ -5611,7 +5626,8 @@ public class Mail.Window : Adw.ApplicationWindow {
                 sort_messages_by_date (cache);
                 save_header_list_cache_now (account, folder, cache);
             }
-            restore_folder_counts_from_cache (account, folder);
+            folder.total = group.previous_total;
+            folder.unread = group.previous_unread;
             if (!is_current_account (account))
                 return;
 
@@ -5747,12 +5763,15 @@ public class Mail.Window : Adw.ApplicationWindow {
                 group.folder = from;
                 group.messages = new GenericArray<Message> ();
                 group.uids = new GenericArray<string> ();
+                group.count_changes = new GenericArray<TransferCountChange> ();
+                group.previous_total = from.total;
+                group.previous_unread = from.unread;
                 groups.add (group);
                 index.set (from.full_name, g);
             }
             groups[g].uids.add (message.uid);
             groups[g].messages.add (message);
-            undo_items.add (new TransferUndoItem () {
+            var undo_item = new TransferUndoItem () {
                 message = message,
                 from = from,
                 uid = message.uid,
@@ -5760,8 +5779,10 @@ public class Mail.Window : Adw.ApplicationWindow {
                 folder_name = message.folder_name,
                 outgoing = message.outgoing,
                 local_only = message.local_only,
-            });
-            apply_local_move (account, message, from, destination);
+            };
+            undo_item.count_change = apply_local_move (account, message, from, destination);
+            undo_items.add (undo_item);
+            groups[g].count_changes.add (undo_item.count_change);
             moved++;
         }
 
@@ -5839,7 +5860,8 @@ public class Mail.Window : Adw.ApplicationWindow {
                 pending.groups[i].folder,
                 pending.destination,
                 pending.groups[i].uids,
-                pending.groups[i].messages
+                pending.groups[i].messages,
+                pending.groups[i].count_changes
             );
         }
     }
@@ -5892,7 +5914,6 @@ public class Mail.Window : Adw.ApplicationWindow {
         var message = item.message;
         var from = item.from;
         var uid = item.uid;
-        var unseen = !message.seen;
         var placeholder_uid = message.uid;
 
         this.hidden_uids.remove (hide_key (account, from, uid));
@@ -5905,12 +5926,13 @@ public class Mail.Window : Adw.ApplicationWindow {
             message.folder_full_name = item.folder_full_name;
         remove_from_folder_cache (account, destination, placeholder_uid);
         add_to_folder_cache (account, from, message);
-        from.total++;
-        if (unseen)
+        if (item.count_change.source_total_decremented)
+            from.total++;
+        if (item.count_change.source_unread_decremented)
             from.unread++;
-        if (destination.total > 0)
+        if (item.count_change.destination_total_incremented && destination.total > 0)
             destination.total--;
-        if (unseen && destination.unread > 0)
+        if (item.count_change.destination_unread_incremented && destination.unread > 0)
             destination.unread--;
     }
 
@@ -5963,15 +5985,26 @@ public class Mail.Window : Adw.ApplicationWindow {
         }
     }
 
-    private void apply_local_move (Account account, Message message, Folder from, Folder destination) {
+    private TransferCountChange apply_local_move (
+        Account account,
+        Message message,
+        Folder from,
+        Folder destination
+    ) {
         var old_uid = message.uid;
         var unseen = !message.seen;
+        var count_change = new TransferCountChange () {
+            source_total_decremented = from.total > 0,
+            source_unread_decremented = unseen && from.unread > 0,
+            destination_total_incremented = true,
+            destination_unread_incremented = unseen,
+        };
         this.hidden_uids.set (hide_key (account, from, old_uid), 1);
         remove_from_folder_cache (account, from, old_uid);
         remove_from_search_results (old_uid, from.full_name);
-        if (from.total > 0)
+        if (count_change.source_total_decremented)
             from.total--;
-        if (unseen && from.unread > 0)
+        if (count_change.source_unread_decremented)
             from.unread--;
         /* UIDs are scoped to a folder. Keeping the source UID in the
          * destination can collide with an unrelated destination message. */
@@ -5984,6 +6017,7 @@ public class Mail.Window : Adw.ApplicationWindow {
         destination.total++;
         if (unseen)
             destination.unread++;
+        return count_change;
     }
 
     private Message make_local_copy (Message source, Folder destination) {
@@ -6087,6 +6121,8 @@ public class Mail.Window : Adw.ApplicationWindow {
                 group.folder = folder;
                 group.messages = new GenericArray<Message> ();
                 group.uids = new GenericArray<string> ();
+                group.previous_total = folder.total;
+                group.previous_unread = folder.unread;
                 groups.add (group);
                 index.set (folder.full_name, g);
             }
@@ -6137,8 +6173,11 @@ public class Mail.Window : Adw.ApplicationWindow {
 
         /* Confirm both UID namespaces after the backend has assigned the real
          * destination UID and removed the source message. */
-        enqueue_sync_job (SYNC_KIND_HEADERS, from, RANK_SELECTED_HEADERS);
-        if (from.full_name != destination.full_name && destination_cache != null)
+        if (!this.mail_session.folder_has_pending_flags (account, from))
+            enqueue_sync_job (SYNC_KIND_HEADERS, from, RANK_SELECTED_HEADERS);
+        if (from.full_name != destination.full_name
+            && destination_cache != null
+            && !this.mail_session.folder_has_pending_flags (account, destination))
             enqueue_sync_job (SYNC_KIND_HEADERS, destination, RANK_SELECTED_HEADERS);
         pump_sync.begin ();
     }
@@ -6160,6 +6199,7 @@ public class Mail.Window : Adw.ApplicationWindow {
         Folder destination,
         GenericArray<string> uids,
         GenericArray<Message>? messages,
+        GenericArray<TransferCountChange>? count_changes,
         string error
     ) {
         var current = is_current_account (account);
@@ -6198,8 +6238,7 @@ public class Mail.Window : Adw.ApplicationWindow {
                     remove_from_search_results (placeholder_uid, destination.full_name);
             }
         }
-        restore_folder_counts_from_cache (account, from);
-        restore_folder_counts_from_cache (account, destination);
+        reverse_failed_transfer_counts (from, destination, count_changes);
         var source_cache = this.message_cache.get (message_cache_key (account, from));
         if (failed_copy) {
             /* These source UIDs were marked Important only for copies that
@@ -6243,8 +6282,11 @@ public class Mail.Window : Adw.ApplicationWindow {
             display_search_results (this.search_results);
         else
             redisplay_current_list ();
-        enqueue_sync_job (SYNC_KIND_HEADERS, from, RANK_SELECTED_HEADERS);
-        if (from.full_name != destination.full_name && destination_cache != null)
+        if (!this.mail_session.folder_has_pending_flags (account, from))
+            enqueue_sync_job (SYNC_KIND_HEADERS, from, RANK_SELECTED_HEADERS);
+        if (from.full_name != destination.full_name
+            && destination_cache != null
+            && !this.mail_session.folder_has_pending_flags (account, destination))
             enqueue_sync_job (SYNC_KIND_HEADERS, destination, RANK_SELECTED_HEADERS);
         pump_sync.begin ();
     }
@@ -6332,6 +6374,27 @@ public class Mail.Window : Adw.ApplicationWindow {
         message_counts (cache, out total, out unread);
         folder.unread = unread;
         folder.total = total;
+    }
+
+    private static void reverse_failed_transfer_counts (
+        Folder source,
+        Folder destination,
+        GenericArray<TransferCountChange>? count_changes
+    ) {
+        if (count_changes == null)
+            return;
+
+        for (uint i = 0; i < count_changes.length; i++) {
+            var change = count_changes[i];
+            if (change.source_total_decremented)
+                source.total++;
+            if (change.source_unread_decremented)
+                source.unread++;
+            if (change.destination_total_incremented && destination.total > 0)
+                destination.total--;
+            if (change.destination_unread_incremented && destination.unread > 0)
+                destination.unread--;
+        }
     }
 
     private void drop_conversation_row (Conversation conversation) {
@@ -6999,6 +7062,8 @@ public class Mail.Window : Adw.ApplicationWindow {
 
         var key = message_cache_key (account, folder);
         var cache = this.message_cache.get (key);
+        var previous_total = folder.total;
+        var previous_unread = folder.unread;
         if (cache != null) {
             for (uint i = 0; i < cache.length; i++)
                 this.hidden_uids.set (hide_key (account, folder, cache[i].uid), 1);
@@ -7033,8 +7098,9 @@ public class Mail.Window : Adw.ApplicationWindow {
                 this.message_cache.set (key, cache);
                 for (uint i = 0; i < cache.length; i++)
                     this.hidden_uids.remove (hide_key (account, folder, cache[i].uid));
-                restore_folder_counts_from_cache (account, folder);
             }
+            folder.total = previous_total;
+            folder.unread = previous_unread;
             if (!is_current_account (account))
                 return;
 
@@ -7967,6 +8033,9 @@ private class Mail.FolderMessageGroup {
     public Folder folder;
     public GenericArray<Message> messages;
     public GenericArray<string> uids;
+    public GenericArray<TransferCountChange>? count_changes;
+    public int previous_total;
+    public int previous_unread;
 }
 
 private class Mail.TransferUndoItem {
@@ -7977,6 +8046,7 @@ private class Mail.TransferUndoItem {
     public string folder_name;
     public bool outgoing;
     public bool local_only;
+    public TransferCountChange count_change;
 }
 
 private class Mail.PendingTransferUndo {

--- a/src/window.vala
+++ b/src/window.vala
@@ -5124,9 +5124,10 @@ public class Mail.Window : Adw.ApplicationWindow {
                         && !(message.msgid_hash != 0 && dest_cache[j].msgid_hash == message.msgid_hash))
                         continue;
                     removed_copy = dest_cache[j];
-                    dest_cache.remove_index (j);
                     break;
                 }
+                if (removed_copy != null)
+                    removed_copy.pending_important_removal = true;
                 delete_important_copy.begin (
                     account,
                     folder,
@@ -5164,13 +5165,68 @@ public class Mail.Window : Adw.ApplicationWindow {
     ) {
         if (this.mail_session == null)
             return;
-        var uids = new GenericArray<string> ();
-        uids.add (uid);
+        var placeholder_uid = uid.has_prefix ("local-copy-") ? uid : null;
         try {
+            if (placeholder_uid != null) {
+                /* Never send a window-local placeholder UID to Camel. Wait for
+                 * its queued copy, then use COPYUID or a refreshed unique match. */
+                yield this.mail_session.flush_pending_local_changes ();
+                if (removed_copy != null && !removed_copy.uid.has_prefix ("local-copy-")) {
+                    uid = removed_copy.uid;
+                } else {
+                    var resolved = yield this.mail_session.find_matching_uid (
+                        account,
+                        destination,
+                        source
+                    );
+                    if (resolved == null) {
+                        /* A failed queued copy already achieved the requested
+                         * unimportant state. An unresolved successful copy must
+                         * remain visible until it can be identified safely. */
+                        if (this.mail_session.has_pending_transfer (
+                            account,
+                            destination,
+                            placeholder_uid
+                        )) {
+                            throw new IOError.NOT_FOUND (
+                                _("This message is still syncing with the server. Try again in a moment.")
+                            );
+                        }
+                        return;
+                    }
+                    uid = resolved;
+                }
+            }
+
+            var uids = new GenericArray<string> ();
+            uids.add (uid);
             yield this.mail_session.delete_uids (account, destination, uids, null);
+            if (placeholder_uid != null) {
+                this.mail_session.discard_pending_transfer (
+                    account,
+                    destination,
+                    placeholder_uid
+                );
+            }
+            if (removed_copy != null)
+                remove_from_folder_cache (account, destination, removed_copy.uid);
+            if (placeholder_uid != null)
+                remove_from_folder_cache (account, destination, placeholder_uid);
+            remove_from_folder_cache (account, destination, uid);
+
+            var destination_cache = this.message_cache.get (
+                message_cache_key (account, destination)
+            );
+            if (destination_cache != null)
+                save_header_list_cache_now (account, destination, destination_cache);
+            if (is_current_account (account)) {
+                refresh_folder_badge (destination);
+                sync_important_markers ();
+            }
         } catch (Error e) {
             debug ("Could not clear Important: %s", e.message);
             if (removed_copy != null) {
+                removed_copy.pending_important_removal = false;
                 removed_copy.important = true;
                 add_to_folder_cache (account, destination, removed_copy);
             }
@@ -5217,7 +5273,22 @@ public class Mail.Window : Adw.ApplicationWindow {
         var cached = this.message_cache.get (message_cache_key (account, folder));
         if (cached == null)
             return null;
-        return MailSession.matching_message_uid (cached, message);
+        var uid = MailSession.matching_message_uid (cached, message);
+        if (uid != null)
+            return uid;
+
+        /* A deferred copy has no server UID yet, but it retains the exact
+         * source identity so toggling Important off can order after that copy. */
+        for (uint i = 0; i < cached.length; i++) {
+            var candidate = cached[i];
+            if (!candidate.uid.has_prefix ("local-copy-")
+                || candidate.transfer_source_uid != message.uid
+                || (candidate.transfer_source_folder ?? "")
+                    != (message.folder_full_name ?? ""))
+                continue;
+            return candidate.uid;
+        }
+        return null;
     }
 
     private void sync_important_markers () {
@@ -5233,6 +5304,8 @@ public class Mail.Window : Adw.ApplicationWindow {
         var cached = this.message_cache.get (message_cache_key (account, important));
         if (cached != null) {
             for (uint i = 0; i < cached.length; i++) {
+                if (cached[i].pending_important_removal)
+                    continue;
                 cached[i].important = true;
                 if (cached[i].msgid_hash != 0)
                     hashes.set (cached[i].msgid_hash.to_string (), 1);
@@ -6046,6 +6119,8 @@ public class Mail.Window : Adw.ApplicationWindow {
             conversation_key = source.conversation_key,
             search_blob = source.search_blob,
             local_only = true,
+            transfer_source_uid = source.uid,
+            transfer_source_folder = source.folder_full_name,
         };
     }
 

--- a/src/window.vala
+++ b/src/window.vala
@@ -5473,10 +5473,22 @@ public class Mail.Window : Adw.ApplicationWindow {
                 save_header_list_cache_now (account, folder, cache);
         } catch (Error e) {
             this.hidden_uids.remove (hide_key (account, folder, uid));
+            add_to_folder_cache (account, folder, message);
+            restore_to_search_results (message);
+            var cache = this.message_cache.get (message_cache_key (account, folder));
+            if (cache != null) {
+                sort_messages_by_date (cache);
+                save_header_list_cache_now (account, folder, cache);
+            }
+            restore_folder_counts_from_cache (account, folder);
+            refresh_folder_badge (folder);
+            if (is_searching && this.search_results != null)
+                display_search_results (this.search_results);
+            else
+                redisplay_current_list ();
             this.toast_overlay.add_toast (new Adw.Toast (e.message) {
                 timeout = 4,
             });
-            refresh_open_folder.begin (true, false);
         }
     }
 

--- a/src/window.vala
+++ b/src/window.vala
@@ -6033,6 +6033,20 @@ public class Mail.Window : Adw.ApplicationWindow {
         }
     }
 
+    private void restore_to_search_results (Message message) {
+        if (this.search_results == null)
+            return;
+        for (uint i = 0; i < this.search_results.length; i++) {
+            if (this.search_results[i].uid == message.uid
+                && (this.search_results[i].folder_full_name ?? "")
+                    == (message.folder_full_name ?? ""))
+                return;
+        }
+        this.search_results.add (message);
+        sort_messages_by_date (this.search_results);
+        trim_search_results (this.search_results);
+    }
+
     private void on_transfer_completed (Account account, Folder from, Folder destination) {
         var source_cache = this.message_cache.get (message_cache_key (account, from));
         if (source_cache != null)
@@ -6080,22 +6094,33 @@ public class Mail.Window : Adw.ApplicationWindow {
         var failed_copy = false;
         if (messages != null) {
             for (uint i = 0; i < messages.length; i++) {
-                if (messages[i].uid.has_prefix ("local-copy-"))
+                var message = messages[i];
+                var placeholder_uid = message.uid;
+                var copy = placeholder_uid.has_prefix ("local-copy-");
+                if (copy)
                     failed_copy = true;
                 if (i < uids.length) {
                     this.mail_session.rekey_body (
                         account,
                         destination,
-                        messages[i].uid,
+                        placeholder_uid,
                         from,
                         uids[i]
                     );
+                    if (!copy) {
+                        Conversation.apply_folder (message, from, uids[i]);
+                        message.local_only = false;
+                        add_to_folder_cache (account, from, message);
+                        restore_to_search_results (message);
+                    }
                 }
-                remove_from_folder_cache (account, destination, messages[i].uid);
-                remove_from_search_results (messages[i].uid, destination.full_name);
+                remove_from_folder_cache (account, destination, placeholder_uid);
+                remove_from_search_results (placeholder_uid, destination.full_name);
             }
         }
+        restore_folder_counts_from_cache (account, from);
         restore_folder_counts_from_cache (account, destination);
+        refresh_folder_badge (from);
         refresh_folder_badge (destination);
         this.toast_overlay.add_toast (new Adw.Toast (error) {
             timeout = 4,
@@ -6107,12 +6132,16 @@ public class Mail.Window : Adw.ApplicationWindow {
             /* Removing a failed Gmail Important copy also clears the
              * optimistic marker on its source message and persisted caches. */
             sync_important_markers ();
-            var source_cache = this.message_cache.get (message_cache_key (account, from));
-            if (source_cache != null)
-                save_header_list_cache_now (account, from, source_cache);
-            if (destination_cache != null)
-                save_header_list_cache_now (account, destination, destination_cache);
         }
+        var source_cache = this.message_cache.get (message_cache_key (account, from));
+        if (source_cache != null)
+            save_header_list_cache_now (account, from, source_cache);
+        if (destination_cache != null)
+            save_header_list_cache_now (account, destination, destination_cache);
+        if (is_searching && this.search_results != null)
+            display_search_results (this.search_results);
+        else
+            redisplay_current_list ();
         enqueue_sync_job (SYNC_KIND_HEADERS, from, RANK_SELECTED_HEADERS);
         if (from.full_name != destination.full_name && destination_cache != null)
             enqueue_sync_job (SYNC_KIND_HEADERS, destination, RANK_SELECTED_HEADERS);

--- a/src/window.vala
+++ b/src/window.vala
@@ -5201,14 +5201,7 @@ public class Mail.Window : Adw.ApplicationWindow {
         var cached = this.message_cache.get (message_cache_key (account, folder));
         if (cached == null)
             return null;
-        for (uint i = 0; i < cached.length; i++) {
-            var item = cached[i];
-            if (message.msgid_hash != 0 && item.msgid_hash == message.msgid_hash)
-                return item.uid;
-            if (item.uid == message.uid)
-                return item.uid;
-        }
-        return null;
+        return MailSession.matching_message_uid (cached, message);
     }
 
     private void sync_important_markers () {

--- a/src/window.vala
+++ b/src/window.vala
@@ -5819,16 +5819,17 @@ public class Mail.Window : Adw.ApplicationWindow {
         var from = item.from;
         var uid = item.uid;
         var unseen = !message.seen;
+        var placeholder_uid = message.uid;
 
         this.hidden_uids.remove (hide_key (account, from, uid));
+        this.mail_session.rekey_body (account, destination, placeholder_uid, from, uid);
         Conversation.apply_folder (message, from, uid);
         message.folder_name = item.folder_name;
         message.outgoing = item.outgoing;
         message.local_only = item.local_only;
         if (item.folder_full_name != null)
             message.folder_full_name = item.folder_full_name;
-        this.mail_session.rekey_body (account, destination, message.uid, from, uid);
-        remove_from_folder_cache (account, destination, message.uid);
+        remove_from_folder_cache (account, destination, placeholder_uid);
         add_to_folder_cache (account, from, message);
         from.total++;
         if (unseen)

--- a/src/window.vala
+++ b/src/window.vala
@@ -6201,6 +6201,19 @@ public class Mail.Window : Adw.ApplicationWindow {
         restore_folder_counts_from_cache (account, from);
         restore_folder_counts_from_cache (account, destination);
         var source_cache = this.message_cache.get (message_cache_key (account, from));
+        if (failed_copy && source_cache != null) {
+            /* These source UIDs were marked Important only for copies that
+             * just failed. Clear the optimistic state before persisting, even
+             * if the user switched accounts while the request was running. */
+            for (uint i = 0; i < uids.length; i++) {
+                for (uint j = 0; j < source_cache.length; j++) {
+                    if (source_cache[j].uid == uids[i])
+                        source_cache[j].important = false;
+                }
+            }
+            if (current)
+                sync_important_markers ();
+        }
         if (source_cache != null)
             save_header_list_cache_now (account, from, source_cache);
         if (destination_cache != null)
@@ -6213,11 +6226,6 @@ public class Mail.Window : Adw.ApplicationWindow {
         this.toast_overlay.add_toast (new Adw.Toast (error) {
             timeout = 4,
         });
-        if (failed_copy) {
-            /* Removing a failed Gmail Important copy also clears the
-             * optimistic marker on its source message and persisted caches. */
-            sync_important_markers ();
-        }
         if (is_searching && this.search_results != null)
             display_search_results (this.search_results);
         else


### PR DESCRIPTION
## Summary
- upload deleted flags and expunge permanent deletes instead of invoking the offline body cache operation
- immediately flush moves after the undo window, reconcile server-assigned UIDs, and recover optimistic UI state on failure
- refresh selected and idle bulk folders to detect stale equal-count caches and remote flag changes
- persist destructive cache changes and drain pending local operations before shutdown

## Testing
- `meson compile -C _build`
- `meson test -C _build --print-errorlogs` (4/4 passed)
- `git diff --check`